### PR TITLE
Allow Enabling 90Hz mode for Oculus

### DIFF
--- a/Assets/Scripts/UserConfig.cs
+++ b/Assets/Scripts/UserConfig.cs
@@ -305,6 +305,7 @@ namespace TiltBrush
 
             private const float kDefaultSmoothing = 0.98f;
             private const float kDefaultOdsPoleCollapsing = 1.0f;
+            private const float kDefaultDisplayRefresh = 72.0f;
 
             float? m_FPS;
             public float FPS
@@ -476,6 +477,17 @@ namespace TiltBrush
                     }
                 }
             }
+
+            float? m_DisplayRefresh;
+            public float DisplayRefresh
+            {
+                get { return m_DisplayRefresh ?? kDefaultDisplayRefresh; }
+                set
+                {
+                    m_DisplayRefresh = value;
+                }
+            }
+
         }
 
         public VideoConfig Video;

--- a/Assets/Scripts/VrSdk.cs
+++ b/Assets/Scripts/VrSdk.cs
@@ -193,6 +193,22 @@ namespace TiltBrush
                 manager.useRecommendedMSAALevel = false;
 
                 SetControllerStyle(TiltBrush.ControllerStyle.OculusTouch);
+
+                // Set custom refresh rate, if possible. To see the current framerate, look in the logs for prints like this one. The first number is the actual frame rate, the second is the display refresh rate (aka target)
+                // VrApi   : FPS=90/90,Prd=33ms,Tear=0,Early=0...
+                float targetDisplayRefresh = App.UserConfig.Video.DisplayRefresh;
+                float[] freqs = OVRManager.display.displayFrequenciesAvailable;
+                foreach (float freq in freqs)
+                {
+                    if (Math.Abs(freq - targetDisplayRefresh) < 1)
+                    {
+                        OVRPlugin.systemDisplayFrequency = freq;
+                        OVRManager.DisplayRefreshRateChanged += DisplayRefreshRateChanged;
+                        Debug.Log($"Set display refresh to {freq}");
+                        break;
+                    }
+                }
+
                 // adding components to the VR Camera needed for fading view and getting controller poses.
                 m_VrCamera.gameObject.AddComponent<OculusCameraFade>();
                 m_VrCamera.gameObject.AddComponent<OculusPreCullHook>();
@@ -342,6 +358,13 @@ namespace TiltBrush
             InputManager.m_Instance.AllowVrControllers = (bool)args[0];
             m_HasVrFocus = (bool)args[0];
         }
+
+#if OCULUS_SUPPORTED
+        private void DisplayRefreshRateChanged (float fromRefreshRate, float ToRefreshRate)
+        {
+            Debug.LogWarning(string.Format("Refresh rate changed from {0} to {1}", fromRefreshRate, ToRefreshRate));
+        }
+#endif
 
         private void OnNewPoses()
         {


### PR DESCRIPTION
By adding:
```json
{
 ...,
  "Video": {
    "DisplayRefresh": 90,
  },
 ...,
}
```
This PR will allow setting the default display refresh to 90Hz or, presumably, if you have v28, to 120Hz. 