### PR TITLE
[Android] Move user folder to Application.persistentDataPath

### DIFF
--- a/Assets/Scripts/App.cs
+++ b/Assets/Scripts/App.cs
@@ -1960,17 +1960,17 @@ namespace TiltBrush
         {
             var newName = path;
 
-            if(counter != 0)
+            if (counter != 0)
             {
-                newName = $"{Path.GetFileNameWithoutExtension(path)}.{counter+1}.{Path.GetExtension(path)}";
+                newName = $"{Path.GetFileNameWithoutExtension(path)}.{counter + 1}.{Path.GetExtension(path)}";
             }
 
-            if(!File.Exists(newName))
+            if (!File.Exists(newName))
             {
                 return newName;
             }
 
-            return SafeFileName(path, counter+1);
+            return SafeFileName(path, counter + 1);
         }
 
         // Return path of root directory for storing user sketches, snapshots, etc.

--- a/Assets/Scripts/App.cs
+++ b/Assets/Scripts/App.cs
@@ -1898,7 +1898,7 @@ namespace TiltBrush
 
             if (Directory.Exists(m_UserPath))
             {
-                if(File.Exists(Path.Combine(m_UserPath, "MovedFiles.txt")))
+                if (File.Exists(Path.Combine(m_UserPath, "MovedFiles.txt")))
                 {
                     // Files have previously been moved.
                     return;
@@ -1919,7 +1919,7 @@ namespace TiltBrush
                 string moveMessageFilename = Path.Combine(m_OldUserPath, kFileMoveFilename);
                 File.WriteAllText(moveMessageFilename, kFileMoveContents);
 
-                // Signify this operation is comlpete by storing the manifest in the new directory.
+                // Signify this operation is complete by storing the manifest in the new directory.
                 File.WriteAllText(Path.Combine(m_UserPath, "MovedFiles.txt"), String.Join('\n', movedFiles.ToArray()));
 
             }
@@ -1945,7 +1945,7 @@ namespace TiltBrush
             foreach (FileInfo file in dir.GetFiles())
             {
                 string targetFilePath = Path.Combine(destinationDir, file.Name);
-                if(!File.Exists(targetFilePath))
+                if (!File.Exists(targetFilePath))
                 {
                     file.CopyTo(targetFilePath);
                     movedFiles.Add(targetFilePath);

--- a/Assets/Scripts/App.cs
+++ b/Assets/Scripts/App.cs
@@ -72,8 +72,9 @@ namespace TiltBrush
         private const string kFileMoveFilename = "WhereHaveMyFilesGone.txt";
 
         private const string kFileMoveContents =
-            "All your " + kAppDisplayName + " files have been moved to\n" +
-            "/sdcard/" + kAppFolderName + ".\n";
+            "Due to a change in Android security policy all your " + kAppDisplayName + " files have been moved to\n" +
+            "Quest 2\\Internal shared storage\\Android\\data\\com.Icosa.OpenBrush\n" +
+            "Visit the Open Brush Docs for more information: https://docs.openbrush.app";
 
         public enum AppState
         {
@@ -1858,8 +1859,8 @@ namespace TiltBrush
                         "Documents");
                     break;
                 case RuntimePlatform.Android:
-                    m_UserPath = "/sdcard/";
-                    m_OldUserPath = Application.persistentDataPath;
+                    m_UserPath = Application.persistentDataPath;
+                    m_OldUserPath = "/sdcard/";
                     break;
                 case RuntimePlatform.IPhonePlayer:
                 default:
@@ -1902,7 +1903,9 @@ namespace TiltBrush
 
             try
             {
-                Directory.Move(m_OldUserPath, m_UserPath);
+                // Moving does not work across different mount points, have to copy and delete.
+                CopyDirectory(m_OldUserPath, m_UserPath, true);
+                Directory.Delete(m_OldUserPath, true);
                 // Recreate the old directory and put a message in there so a user used to looking in the old
                 // location can find out where to get their files.
                 Directory.CreateDirectory(m_OldUserPath);
@@ -1912,6 +1915,39 @@ namespace TiltBrush
             catch (Exception ex)
             {
                 Debug.LogException(ex);
+            }
+        }
+
+        static void CopyDirectory(string sourceDir, string destinationDir, bool recursive)
+        {
+            // Get information about the source directory
+            var dir = new DirectoryInfo(sourceDir);
+
+            // Check if the source directory exists
+            if (!dir.Exists)
+                throw new DirectoryNotFoundException($"Source directory not found: {dir.FullName}");
+
+            // Cache directories before we start copying
+            DirectoryInfo[] dirs = dir.GetDirectories();
+
+            // Create the destination directory
+            Directory.CreateDirectory(destinationDir);
+
+            // Get the files in the source directory and copy to the destination directory
+            foreach (FileInfo file in dir.GetFiles())
+            {
+                string targetFilePath = Path.Combine(destinationDir, file.Name);
+                file.CopyTo(targetFilePath);
+            }
+
+            // If recursive and copying subdirectories, recursively call this method
+            if (recursive)
+            {
+                foreach (DirectoryInfo subDir in dirs)
+                {
+                    string newDestinationDir = Path.Combine(destinationDir, subDir.Name);
+                    CopyDirectory(subDir.FullName, newDestinationDir, true);
+                }
             }
         }
 


### PR DESCRIPTION
This expands upon the reverted #462 to move files one by one.