### PR TITLE
Base Photon files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,5 +102,10 @@
 # Pico Integration
 Packages/com.unity.xr.picoxr
 
+# Photon Integration
+/Assets/Photon/**
+/Assets/Photon.meta
+!/Assets/Photon/Fusion/Resources/NetworkProjectConfig.fusion*
+
 # Cache files
 *.cache

--- a/Assets/Photon/Fusion/Resources/NetworkProjectConfig.fusion
+++ b/Assets/Photon/Fusion/Resources/NetworkProjectConfig.fusion
@@ -1,0 +1,164 @@
+{
+    "Version": 1,
+    "TypeId": "NetworkProjectConfig",
+    "PeerMode": 0,
+    "PhysicsEngine": 0,
+    "ServerPhysicsMode": 0,
+    "UseLagCompensation": true,
+    "LagCompensation": {
+        "HitboxBufferSize": 12,
+        "HitboxCapacity": 512,
+        "ExpansionFactor": 0.20000000298023225,
+        "Optimize": false,
+        "DebugBroadphase": false,
+        "DebugHistory": false,
+        "DebugColor": {
+            "r": 0.0,
+            "g": 1.0,
+            "b": 0.0,
+            "a": 0.5
+        },
+        "ClientDebugColor": {
+            "r": 0.0,
+            "g": 0.0,
+            "b": 1.0,
+            "a": 0.5
+        },
+        "HistoryDebugColor": {
+            "r": 0.0,
+            "g": 0.0,
+            "b": 1.0,
+            "a": 0.5
+        }
+    },
+    "SceneLoadSpawnMode": 0,
+    "DeltaCompressor": 0,
+    "InvokeRenderInBatchMode": true,
+    "MaxNetworkedObjectCount": 8192,
+    "NetworkIdIsObjectName": false,
+    "HideNetworkObjectInactivityGuard": false,
+    "EnableHostMigration": false,
+    "HostMigrationSnapshotInterval": 60,
+    "Simulation": {
+        "InputDataWordCount": 0,
+        "TickRate": 60,
+        "MaxPrediction": 60,
+        "DefaultPlayers": 10,
+        "ReplicationMode": 0,
+        "ObjectInterest": false,
+        "ServerPacketInterval": 1,
+        "ClientPacketInterval": 1
+    },
+    "Interpolation": {
+        "DeltaAdjustment": 1,
+        "AllowedJitter": 25,
+        "SnapLimit": 200,
+        "MultiplierMin": 1.25,
+        "MultiplierMax": 3.0
+    },
+    "Network": {
+        "SocketSendBufferSize": 256,
+        "SocketRecvBufferSize": 256,
+        "ConnectAttempts": 10,
+        "ConnectInterval": 0.5,
+        "ConnectionDefaultRtt": 0.1,
+        "ConnectionTimeout": 10.0,
+        "ConnectionPingInterval": 1.0,
+        "ConnectionShutdownTime": 1.0,
+        "MtuDefault": 1136,
+        "ReliableDataTransferModes": 3
+    },
+    "NetworkConditions": {
+        "Enabled": false,
+        "DelayShape": 1,
+        "DelayMin": 0.01,
+        "DelayMax": 0.1,
+        "DelayPeriod": 3.0,
+        "DelayThreshold": 0.5,
+        "AdditionalJitter": 0.01,
+        "LossChanceShape": 1,
+        "LossChanceMin": 0.0,
+        "LossChanceMax": 0.02,
+        "LossChanceThreshold": 0.9,
+        "LossChancePeriod": 3.0,
+        "AdditionalLoss": 0.005
+    },
+    "Heap": {
+        "PageShift": 14,
+        "PageCount": 128,
+        "GlobalsSize": 0
+    },
+    "AccuracyDefaults": {
+        "coreKeys": [
+            "Uncompressed",
+            "Default",
+            "Position",
+            "Rotation",
+            "NormalizedTime"
+        ],
+        "coreDefs": [
+            {
+                "_value": 0.0,
+                "_inverse": Infinity,
+                "_hash": -1382104104
+            },
+            {
+                "_value": 0.0010000000474974514,
+                "_inverse": 999.9999389648438,
+                "_hash": -814817977
+            },
+            {
+                "_value": 0.0010000000474974514,
+                "_inverse": 999.9999389648438,
+                "_hash": -194233199
+            },
+            {
+                "_value": 0.0010000000474974514,
+                "_inverse": 999.9999389648438,
+                "_hash": -258202764
+            },
+            {
+                "_value": 0.00009999999747378752,
+                "_inverse": 10000.0,
+                "_hash": 1061325578
+            }
+        ],
+        "coreVals": [
+            {
+                "_value": 0.0,
+                "_inverse": Infinity,
+                "_hash": -1382104104
+            },
+            {
+                "_value": 0.0010000000474974514,
+                "_inverse": 999.9999389648438,
+                "_hash": -814817977
+            },
+            {
+                "_value": 0.0010000000474974514,
+                "_inverse": 999.9999389648438,
+                "_hash": -194233199
+            },
+            {
+                "_value": 0.0010000000474974514,
+                "_inverse": 999.9999389648438,
+                "_hash": -258202764
+            },
+            {
+                "_value": 0.00009999999747378752,
+                "_inverse": 10000.0,
+                "_hash": 1061325578
+            }
+        ],
+        "tags": [],
+        "values": []
+    },
+    "AssembliesToWeave": [
+        "Assembly-CSharp",
+        "Assembly-CSharp-firstpass"
+    ],
+    "UseSerializableDictionary": true,
+    "NullChecksForNetworkedProperties": true,
+    "CheckRpcAttributeUsage": false,
+    "CheckNetworkedPropertiesBeingEmpty": false
+}

--- a/Assets/Photon/Fusion/Resources/NetworkProjectConfig.fusion.meta
+++ b/Assets/Photon/Fusion/Resources/NetworkProjectConfig.fusion.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dd4ca0370d231e84e889cd4edcaf0bde
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 66a64a17d0b40f34f9224317a5a84bf2, type: 3}
+  PrefabAssetsContainerPath: 

--- a/Assets/Scripts/Config.cs
+++ b/Assets/Scripts/Config.cs
@@ -129,6 +129,7 @@ namespace TiltBrush
         public SecretsConfig.ServiceAuthData OculusSecrets => Secrets[SecretsConfig.Service.Oculus];
         public SecretsConfig.ServiceAuthData OculusMobileSecrets => Secrets[SecretsConfig.Service.OculusMobile];
         public SecretsConfig.ServiceAuthData PimaxSecrets => Secrets[SecretsConfig.Service.Pimax];
+        public SecretsConfig.ServiceAuthData PhotonFusionSecrets => Secrets[SecretsConfig.Service.PhotonFusion];
 
         /// Return a value kinda sorta half-way between "building for Android" and "running on Android"
         /// In order of increasing strictness, here are the in-Editor semantics of various methods

--- a/Assets/Scripts/SecretsConfig.cs
+++ b/Assets/Scripts/SecretsConfig.cs
@@ -25,7 +25,8 @@ public class SecretsConfig : ScriptableObject
         Sketchfab = 1,
         Oculus = 2,
         OculusMobile = 3,
-        Pimax = 4
+        Pimax = 4,
+        PhotonFusion = 5,
     }
 
     [Serializable]

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -12,6 +12,7 @@
     "com.unity.inputsystem": "https://github.com/icosa-mirror/com.unity.inputsystem.git#open-brush",
     "com.unity.localization": "1.4.2",
     "com.unity.mobile.android-logcat": "1.3.2",
+    "com.unity.nuget.mono-cecil": "1.10.2",
     "com.unity.performance.profile-analyzer": "1.1.1",
     "com.unity.test-framework": "1.1.33",
     "com.unity.textmeshpro": "3.0.6",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -141,6 +141,13 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.nuget.mono-cecil": {
+      "version": "1.10.2",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
     "com.unity.nuget.newtonsoft-json": {
       "version": "3.0.2",
       "depth": 1,


### PR DESCRIPTION
.gitignore's everything we don't need, while including the network config file and a way to recover the photon App ID from our secrets file.

When we add the rest of the photon files in CI, we need to make sure we don't overwrite the custom network config file and it's .meta