### PR TITLE
Remove some il2cpp files from Library before saving the cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -401,6 +401,20 @@ jobs:
         with:
           name: ${{ matrix.name }}
           path: build
+      - name: Clean Library before caching
+        run: |
+          # Remove the large files from the Library directory that we know we'll rebuild. As our il2cpp caches are huge and barely fit in the Github quota, it's better not to save an unneeded 1GB of space (or so). If a new Unity version is taken, this may need to be updated
+          # Debugging
+          echo "Library/ directories"
+          du -mcsh Library/*
+          find Library -size +50M -exec ls -altrh {} \;
+          # chown all files, since some are owned by root after the docker run
+          docker run -v $(pwd)/Library:/mnt alpine chown $(id -u).$(id -g) -R /mnt/
+          # Print the files to be deleted
+          find Library/Bee/ -name 'symbols.zip' -or -name 'libil2cpp*.so' -or -name 'launcher-release.apk' | tee todelete.txt
+          cat todelete.txt | xargs -r rm
+          echo "Final space used"
+          du -mcsh Library
 
   release:
     name: Create Github Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,6 +182,11 @@ jobs:
             vrsdk: Monoscopic
             cache: Linux
 
+          - name: MacOS Monoscopic
+            targetPlatform: StandaloneOSX
+            vrsdk: Monoscopic
+            cache: MacOS
+
           - name: Android OpenXR
             targetPlatform: Android
             vrsdk: OpenXR


### PR DESCRIPTION
symbols.zip, launcher apk, and the *.so files. These will need to be regenerated anyway, and it barely saves any time in any case, but they take up a lot of space; without this change, our Android platform caches are about 3.2 - 3.4GB whereas Desktop builds are about 1.1 - 1.3GB. With this change, the Android ones drop to about 2.2 GB.