### PR TITLE
JSON exports also include the sketch metadata

### DIFF
--- a/Assets/Scripts/Export/Export.cs
+++ b/Assets/Scripts/Export/Export.cs
@@ -145,6 +145,9 @@ URL=" + kExportDocumentationUrl;
                 {
                     OverlayManager.m_Instance.UpdateProgress(0.1f);
                     ExportRaw.Export(filename);
+
+                    // Also write the metadata that would normally go in the .tilt file
+                    SketchSnapshot.ExportMetadata(filename.Replace(".json", ".metadata.json"));
                 }
             progress.CompleteWork("json");
 


### PR DESCRIPTION
JSON export now writes an additional file that is mostly identical to the JSON usually written to the .tilt file itself.

I intend to make use of this in the Unity SDK to recreate camera paths (and maybe also lighting and other useful info stored in the metadata.