### PR TITLE
Don't overwrite user colour unless we're in multimirror mode

### DIFF
--- a/Assets/Scripts/PointerManager.cs
+++ b/Assets/Scripts/PointerManager.cs
@@ -1487,7 +1487,9 @@ namespace TiltBrush
                     }
                 }
 
-                if (m_SymmetryColorShiftEnabled)
+                // Currently only Multimirror mode shows UI for color shift
+                // So disable it for all other modes
+                if (m_SymmetryColorShiftEnabled && m_CurrentSymmetryMode == SymmetryMode.MultiMirror)
                 {
                     script.SetColor(m_SymmetryPointerColors[i % m_SymmetryPointerColors.Count]);
                 }


### PR DESCRIPTION
Colour jitter for normal painting is currently not working at all in the beta due to the colour choice being overwritten by the colours set in the multimirror panel.

This fixes that issue.