### PR TITLE
Settings panel didn't reflect correct experimental mode state.

### DIFF
--- a/Assets/Prefabs/Panels/SettingsPanel.prefab
+++ b/Assets/Prefabs/Panels/SettingsPanel.prefab
@@ -889,7 +889,7 @@ MonoBehaviour:
   m_UseGazeRotation: 1
   m_MaxGazeRotation: 20
   m_GazeActivateSpeed: 8
-  m_InitialSpawnPos: {x: 0, y: 0, z: 0}
+  m_InitialSpawnPos: {x: 0, y: 13, z: 5}
   m_InitialSpawnRotEulers: {x: 0, y: 0, z: 0}
   m_WandAttachAngle: 0
   m_WandAttachYOffset: 0
@@ -899,6 +899,7 @@ MonoBehaviour:
   m_CanBeDetachedFromWand: 0
   m_PopUpGazeDuration: 0.2
   m_PromoBorders: []
+  m_ExperimentalModeToggle: {fileID: 7923957768018575614}
   references:
     version: 2
     RefIds: []

--- a/Assets/Scripts/GUI/AppSettingsPanel.cs
+++ b/Assets/Scripts/GUI/AppSettingsPanel.cs
@@ -19,6 +19,14 @@ namespace TiltBrush
     public class AppSettingsPanel : BasePanel
     {
 
+        public ToggleButton m_ExperimentalModeToggle;
+
+        public override void InitPanel()
+        {
+            base.InitPanel();
+            m_ExperimentalModeToggle.IsToggledOn = App.Config.GetIsExperimental();
+        }
+
         public void HandleToggleHandedness()
         {
             SketchControlsScript.DoSwapControls();


### PR DESCRIPTION
(Also - initial panel position was at origin in monoscopic)