### PR TITLE
Remove passthrough prefab if not supported

### DIFF
--- a/Assets/Scripts/GUI/LightingPopUpWindow.cs
+++ b/Assets/Scripts/GUI/LightingPopUpWindow.cs
@@ -46,6 +46,23 @@ namespace TiltBrush
             //build list of lighting presets we're going to show
             m_Environments = EnvironmentCatalog.m_Instance.AllEnvironments.ToList();
 
+            // Remove passthrough scene for devices that don't support it
+            // (everything but Quest).
+            // TODO: Better way to detect Passthrough support.
+            // Extra: Passthrough should be *per* envrionment really!
+            // See https://github.com/icosa-foundation/open-brush/issues/456
+#if !OCULUS_SUPPORTED
+            foreach (var env in m_Environments)
+            {
+                // Passthrough
+                if (env.m_Guid.ToString() == "e38af599-4575-46ff-a040-459703dbcd36")
+                {
+                    m_Environments.Remove(env);
+                    break;
+                }
+            }
+#endif // OCULUS_SUPPORTED
+
             //find the active lighting preset
             TiltBrush.Environment rCurrentPreset = SceneSettings.m_Instance.GetDesiredPreset();
             if (rCurrentPreset != null)

--- a/Assets/Scripts/GUI/LightingPopUpWindow.cs
+++ b/Assets/Scripts/GUI/LightingPopUpWindow.cs
@@ -54,7 +54,7 @@ namespace TiltBrush
             m_Environments = EnvironmentCatalog.m_Instance.AllEnvironments.ToList();
 
             // Remove passthrough scene for devices that don't support it
-#if PASSTHROUGH_SUPPORTED
+#if !PASSTHROUGH_SUPPORTED
             foreach (var env in m_Environments)
             {
                 // Passthrough

--- a/Assets/Scripts/GUI/LightingPopUpWindow.cs
+++ b/Assets/Scripts/GUI/LightingPopUpWindow.cs
@@ -12,6 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// TODO: Better way to detect Passthrough support.
+// Extra: Passthrough should be *per* envrionment really!
+// See https://github.com/icosa-foundation/open-brush/issues/456
+#if OCULUS_SUPPORTED
+#define PASSTHROUGH_SUPPORTED
+#endif
+
 using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
@@ -47,11 +54,7 @@ namespace TiltBrush
             m_Environments = EnvironmentCatalog.m_Instance.AllEnvironments.ToList();
 
             // Remove passthrough scene for devices that don't support it
-            // (everything but Quest).
-            // TODO: Better way to detect Passthrough support.
-            // Extra: Passthrough should be *per* envrionment really!
-            // See https://github.com/icosa-foundation/open-brush/issues/456
-#if !OCULUS_SUPPORTED
+#if PASSTHROUGH_SUPPORTED
             foreach (var env in m_Environments)
             {
                 // Passthrough
@@ -61,7 +64,7 @@ namespace TiltBrush
                     break;
                 }
             }
-#endif // OCULUS_SUPPORTED
+#endif // PASSTHROUGH_SUPPORTED
 
             //find the active lighting preset
             TiltBrush.Environment rCurrentPreset = SceneSettings.m_Instance.GetDesiredPreset();


### PR DESCRIPTION
Listing passthrough environment at the start of the environments list, only for it to show a black screen, is a bit of a let-down. Let's temporarily remove it from any officially unsupported platform (that is, everything but Quest).