### PR TITLE
Fix sketchbook context menu button being disabled for first button

### DIFF
--- a/Assets/Scripts/GUI/SketchbookMenuPopUpWindow.cs
+++ b/Assets/Scripts/GUI/SketchbookMenuPopUpWindow.cs
@@ -22,11 +22,11 @@ namespace TiltBrush
     {
         public override void SetPopupCommandParameters(int iCommandParam, int iCommandParam2)
         {
-            // TODO : Fix this hangnail.
             OptionButton[] optionButtons = GetComponentsInChildren<OptionButton>();
             foreach (OptionButton button in optionButtons)
             {
-                if (iCommandParam == 0)
+                // The context menu button should only be enabled for valid sketches
+                if (iCommandParam == -1)
                 {
                     button.SetButtonAvailable(false);
                 }


### PR DESCRIPTION
I had used 0 as the "invalid" flag for sketch buttons instead of -1