### PR TITLE
Allow distinct Quest vs Experimental panel config

### DIFF
--- a/Assets/Editor/PanelMapKeyDrawer.cs
+++ b/Assets/Editor/PanelMapKeyDrawer.cs
@@ -73,6 +73,12 @@ namespace TiltBrush
                 EditorGUI.LabelField(drawRect, new GUIContent("Exp"));
 
                 NextRect(baseX, pos.y, 10, baseHeight, 12);
+                EditorGUI.PropertyField(drawRect, prop.FindPropertyRelative("m_ModeQuestExperimental"),
+                    GUIContent.none);
+                NextRect(baseX, pos.y, 30, baseHeight, 30);
+                EditorGUI.LabelField(drawRect, new GUIContent("ExpQ"));
+
+                NextRect(baseX, pos.y, 10, baseHeight, 12);
                 EditorGUI.PropertyField(drawRect, prop.FindPropertyRelative("m_ModeMono"), GUIContent.none);
                 NextRect(baseX, pos.y, 30, baseHeight, 30);
                 EditorGUI.LabelField(drawRect, new GUIContent("Mo", "Monoscopic"));

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -29154,6 +29154,7 @@ MonoBehaviour:
   - m_PanelPrefab: {fileID: 0}
     m_ModeVr: 0
     m_ModeVrExperimental: 0
+    m_ModeQuestExperimental: 0
     m_ModeMono: 0
     m_ModeQuest: 0
     m_ModeGvr: 0
@@ -29163,6 +29164,7 @@ MonoBehaviour:
       type: 3}
     m_ModeVr: 1
     m_ModeVrExperimental: 1
+    m_ModeQuestExperimental: 1
     m_ModeMono: 1
     m_ModeQuest: 1
     m_ModeGvr: 1
@@ -29171,6 +29173,7 @@ MonoBehaviour:
   - m_PanelPrefab: {fileID: 118774, guid: c736e99e0a7c16340b761d84a4e808d4, type: 3}
     m_ModeVr: 1
     m_ModeVrExperimental: 0
+    m_ModeQuestExperimental: 0
     m_ModeMono: 1
     m_ModeQuest: 0
     m_ModeGvr: 0
@@ -29179,6 +29182,7 @@ MonoBehaviour:
   - m_PanelPrefab: {fileID: 0}
     m_ModeVr: 0
     m_ModeVrExperimental: 0
+    m_ModeQuestExperimental: 0
     m_ModeMono: 0
     m_ModeQuest: 0
     m_ModeGvr: 0
@@ -29188,6 +29192,7 @@ MonoBehaviour:
       type: 3}
     m_ModeVr: 0
     m_ModeVrExperimental: 0
+    m_ModeQuestExperimental: 1
     m_ModeMono: 0
     m_ModeQuest: 1
     m_ModeGvr: 1
@@ -29197,6 +29202,7 @@ MonoBehaviour:
       type: 3}
     m_ModeVr: 0
     m_ModeVrExperimental: 0
+    m_ModeQuestExperimental: 1
     m_ModeMono: 0
     m_ModeQuest: 1
     m_ModeGvr: 1
@@ -29205,6 +29211,7 @@ MonoBehaviour:
   - m_PanelPrefab: {fileID: 152754, guid: 1f98c5464e57ca042986684865c6c8e0, type: 3}
     m_ModeVr: 1
     m_ModeVrExperimental: 1
+    m_ModeQuestExperimental: 0
     m_ModeMono: 1
     m_ModeQuest: 0
     m_ModeGvr: 0
@@ -29213,6 +29220,7 @@ MonoBehaviour:
   - m_PanelPrefab: {fileID: 176644, guid: 82e9561ccc4f9d646b8d328e8a736c62, type: 3}
     m_ModeVr: 0
     m_ModeVrExperimental: 1
+    m_ModeQuestExperimental: 1
     m_ModeMono: 1
     m_ModeQuest: 0
     m_ModeGvr: 0
@@ -29222,6 +29230,7 @@ MonoBehaviour:
       type: 3}
     m_ModeVr: 0
     m_ModeVrExperimental: 0
+    m_ModeQuestExperimental: 1
     m_ModeMono: 0
     m_ModeQuest: 1
     m_ModeGvr: 1
@@ -29231,6 +29240,7 @@ MonoBehaviour:
       type: 3}
     m_ModeVr: 1
     m_ModeVrExperimental: 1
+    m_ModeQuestExperimental: 1
     m_ModeMono: 1
     m_ModeQuest: 1
     m_ModeGvr: 1
@@ -29239,6 +29249,7 @@ MonoBehaviour:
   - m_PanelPrefab: {fileID: 199434, guid: ec8bfc3daf3140a40b74246785710580, type: 3}
     m_ModeVr: 1
     m_ModeVrExperimental: 1
+    m_ModeQuestExperimental: 0
     m_ModeMono: 1
     m_ModeQuest: 0
     m_ModeGvr: 0
@@ -29247,6 +29258,7 @@ MonoBehaviour:
   - m_PanelPrefab: {fileID: 109932, guid: 11a71a8b70e19254abe00d5e569f428c, type: 3}
     m_ModeVr: 1
     m_ModeVrExperimental: 1
+    m_ModeQuestExperimental: 0
     m_ModeMono: 1
     m_ModeQuest: 0
     m_ModeGvr: 0
@@ -29256,6 +29268,7 @@ MonoBehaviour:
       type: 3}
     m_ModeVr: 0
     m_ModeVrExperimental: 0
+    m_ModeQuestExperimental: 1
     m_ModeMono: 0
     m_ModeQuest: 1
     m_ModeGvr: 1
@@ -29265,6 +29278,7 @@ MonoBehaviour:
       type: 3}
     m_ModeVr: 0
     m_ModeVrExperimental: 0
+    m_ModeQuestExperimental: 1
     m_ModeMono: 0
     m_ModeQuest: 1
     m_ModeGvr: 1
@@ -29273,6 +29287,7 @@ MonoBehaviour:
   - m_PanelPrefab: {fileID: 160214, guid: dd236f92a2697d449b2a758b7b42ec17, type: 3}
     m_ModeVr: 1
     m_ModeVrExperimental: 1
+    m_ModeQuestExperimental: 0
     m_ModeMono: 1
     m_ModeQuest: 0
     m_ModeGvr: 0
@@ -29281,6 +29296,7 @@ MonoBehaviour:
   - m_PanelPrefab: {fileID: 192154, guid: 540f829b5f1ea7743be79be2582e1a38, type: 3}
     m_ModeVr: 1
     m_ModeVrExperimental: 1
+    m_ModeQuestExperimental: 1
     m_ModeMono: 1
     m_ModeQuest: 1
     m_ModeGvr: 1
@@ -29289,6 +29305,7 @@ MonoBehaviour:
   - m_PanelPrefab: {fileID: 141494, guid: 0053ac08708148641bd0b629e8e3e2e5, type: 3}
     m_ModeVr: 1
     m_ModeVrExperimental: 1
+    m_ModeQuestExperimental: 0
     m_ModeMono: 1
     m_ModeQuest: 0
     m_ModeGvr: 0
@@ -29297,6 +29314,7 @@ MonoBehaviour:
   - m_PanelPrefab: {fileID: 159900, guid: c5747cd6fc6d92b4b941d58d649877ef, type: 3}
     m_ModeVr: 1
     m_ModeVrExperimental: 1
+    m_ModeQuestExperimental: 1
     m_ModeMono: 1
     m_ModeQuest: 1
     m_ModeGvr: 1
@@ -29305,6 +29323,7 @@ MonoBehaviour:
   - m_PanelPrefab: {fileID: 162374, guid: 1cb57c13fa6b529488ff10d4d47cd359, type: 3}
     m_ModeVr: 1
     m_ModeVrExperimental: 1
+    m_ModeQuestExperimental: 1
     m_ModeMono: 1
     m_ModeQuest: 1
     m_ModeGvr: 1
@@ -29313,6 +29332,7 @@ MonoBehaviour:
   - m_PanelPrefab: {fileID: 176644, guid: 898df100b7777cd40b9e51b8df90ddfd, type: 3}
     m_ModeVr: 1
     m_ModeVrExperimental: 1
+    m_ModeQuestExperimental: 1
     m_ModeMono: 1
     m_ModeQuest: 1
     m_ModeGvr: 1
@@ -29322,6 +29342,7 @@ MonoBehaviour:
       type: 3}
     m_ModeVr: 1
     m_ModeVrExperimental: 1
+    m_ModeQuestExperimental: 1
     m_ModeMono: 1
     m_ModeQuest: 1
     m_ModeGvr: 1
@@ -29330,6 +29351,7 @@ MonoBehaviour:
   - m_PanelPrefab: {fileID: 176644, guid: a7d344d3f87214b40adfb90fb5ab01f5, type: 3}
     m_ModeVr: 0
     m_ModeVrExperimental: 0
+    m_ModeQuestExperimental: 0
     m_ModeMono: 0
     m_ModeQuest: 0
     m_ModeGvr: 0
@@ -29338,6 +29360,7 @@ MonoBehaviour:
   - m_PanelPrefab: {fileID: 141494, guid: a71be6f60d7230c46b3f4c851f6f5933, type: 3}
     m_ModeVr: 1
     m_ModeVrExperimental: 1
+    m_ModeQuestExperimental: 0
     m_ModeMono: 1
     m_ModeQuest: 0
     m_ModeGvr: 0
@@ -29346,6 +29369,7 @@ MonoBehaviour:
   - m_PanelPrefab: {fileID: 118774, guid: ccf3c045c4caee34386327d7023b10cf, type: 3}
     m_ModeVr: 0
     m_ModeVrExperimental: 1
+    m_ModeQuestExperimental: 0
     m_ModeMono: 0
     m_ModeQuest: 0
     m_ModeGvr: 0
@@ -29355,6 +29379,7 @@ MonoBehaviour:
       type: 3}
     m_ModeVr: 1
     m_ModeVrExperimental: 1
+    m_ModeQuestExperimental: 0
     m_ModeMono: 1
     m_ModeQuest: 0
     m_ModeGvr: 0
@@ -29364,6 +29389,7 @@ MonoBehaviour:
       type: 3}
     m_ModeVr: 0
     m_ModeVrExperimental: 0
+    m_ModeQuestExperimental: 1
     m_ModeMono: 0
     m_ModeQuest: 1
     m_ModeGvr: 1
@@ -29373,6 +29399,7 @@ MonoBehaviour:
       type: 3}
     m_ModeVr: 1
     m_ModeVrExperimental: 1
+    m_ModeQuestExperimental: 0
     m_ModeMono: 1
     m_ModeQuest: 0
     m_ModeGvr: 0
@@ -29382,6 +29409,7 @@ MonoBehaviour:
       type: 3}
     m_ModeVr: 1
     m_ModeVrExperimental: 1
+    m_ModeQuestExperimental: 0
     m_ModeMono: 1
     m_ModeQuest: 0
     m_ModeGvr: 0
@@ -29391,6 +29419,7 @@ MonoBehaviour:
       type: 3}
     m_ModeVr: 0
     m_ModeVrExperimental: 0
+    m_ModeQuestExperimental: 1
     m_ModeMono: 0
     m_ModeQuest: 1
     m_ModeGvr: 1
@@ -29400,6 +29429,7 @@ MonoBehaviour:
       type: 3}
     m_ModeVr: 0
     m_ModeVrExperimental: 0
+    m_ModeQuestExperimental: 1
     m_ModeMono: 0
     m_ModeQuest: 1
     m_ModeGvr: 1
@@ -29408,6 +29438,7 @@ MonoBehaviour:
   - m_PanelPrefab: {fileID: 199434, guid: da22f81315a0e724887dc7c8b38b71b4, type: 3}
     m_ModeVr: 0
     m_ModeVrExperimental: 0
+    m_ModeQuestExperimental: 1
     m_ModeMono: 0
     m_ModeQuest: 1
     m_ModeGvr: 1
@@ -29417,6 +29448,7 @@ MonoBehaviour:
       type: 3}
     m_ModeVr: 0
     m_ModeVrExperimental: 0
+    m_ModeQuestExperimental: 1
     m_ModeMono: 0
     m_ModeQuest: 1
     m_ModeGvr: 1
@@ -29426,6 +29458,7 @@ MonoBehaviour:
       type: 3}
     m_ModeVr: 1
     m_ModeVrExperimental: 1
+    m_ModeQuestExperimental: 0
     m_ModeMono: 1
     m_ModeQuest: 0
     m_ModeGvr: 0
@@ -29434,6 +29467,7 @@ MonoBehaviour:
   - m_PanelPrefab: {fileID: 176644, guid: a7d344d3f87214b40adfb90fb5ab01f5, type: 3}
     m_ModeVr: 0
     m_ModeVrExperimental: 0
+    m_ModeQuestExperimental: 0
     m_ModeMono: 0
     m_ModeQuest: 0
     m_ModeGvr: 0
@@ -29443,6 +29477,7 @@ MonoBehaviour:
       type: 3}
     m_ModeVr: 1
     m_ModeVrExperimental: 1
+    m_ModeQuestExperimental: 0
     m_ModeMono: 1
     m_ModeQuest: 0
     m_ModeGvr: 0
@@ -29451,6 +29486,7 @@ MonoBehaviour:
   - m_PanelPrefab: {fileID: 199434, guid: 87deb34c3f9672645984b6032a6c1f8d, type: 3}
     m_ModeVr: 1
     m_ModeVrExperimental: 1
+    m_ModeQuestExperimental: 1
     m_ModeMono: 1
     m_ModeQuest: 1
     m_ModeGvr: 1
@@ -29459,6 +29495,7 @@ MonoBehaviour:
   - m_PanelPrefab: {fileID: 199434, guid: de22d465caf3f20419b98ce5290a7e57, type: 3}
     m_ModeVr: 1
     m_ModeVrExperimental: 1
+    m_ModeQuestExperimental: 1
     m_ModeMono: 1
     m_ModeQuest: 1
     m_ModeGvr: 1
@@ -29467,6 +29504,7 @@ MonoBehaviour:
   - m_PanelPrefab: {fileID: 199434, guid: 6dafd36d9488aba4a998d2ef69ea2553, type: 3}
     m_ModeVr: 1
     m_ModeVrExperimental: 1
+    m_ModeQuestExperimental: 1
     m_ModeMono: 1
     m_ModeQuest: 1
     m_ModeGvr: 1
@@ -29475,6 +29513,7 @@ MonoBehaviour:
   - m_PanelPrefab: {fileID: 176644, guid: d620d9effac3e6c4eaae746d85edf13c, type: 3}
     m_ModeVr: 1
     m_ModeVrExperimental: 1
+    m_ModeQuestExperimental: 1
     m_ModeMono: 1
     m_ModeQuest: 1
     m_ModeGvr: 1
@@ -29483,6 +29522,7 @@ MonoBehaviour:
   - m_PanelPrefab: {fileID: 160214, guid: 2b8f8dc5c7f70ba4eaf8f6a7181d8fc7, type: 3}
     m_ModeVr: 1
     m_ModeVrExperimental: 1
+    m_ModeQuestExperimental: 1
     m_ModeMono: 1
     m_ModeQuest: 1
     m_ModeGvr: 1

--- a/Assets/Scripts/GUI/PanelManager.cs
+++ b/Assets/Scripts/GUI/PanelManager.cs
@@ -25,6 +25,7 @@ namespace TiltBrush
         public GameObject m_PanelPrefab;
         public bool m_ModeVr;
         public bool m_ModeVrExperimental;
+        public bool m_ModeQuestExperimental;
         public bool m_ModeMono;
         public bool m_ModeQuest;
         public bool m_ModeGvr;
@@ -38,11 +39,11 @@ namespace TiltBrush
                 case SdkMode.UnityXR:
                     if (Config.IsExperimental)
                     {
+                        if (App.Config.IsMobileHardware)
+                        {
+                            return m_ModeQuestExperimental;
+                        }
                         return m_ModeVrExperimental;
-                    }
-                    if (App.Config.IsMobileHardware)
-                    {
-                        return m_ModeQuest;
                     }
                     return m_ModeVr;
                 case SdkMode.Monoscopic:


### PR DESCRIPTION
This changes the logic about which panels to show in experimental mode.

Previously "experimental" overrode "standalone vr" so desktop panels were shown on Quest etc when in experimental mode.

This adds another flag to the panel map and sets it so (currently) standalone headsets get the same panels as they do in non-experimental mode aside from showing the experimental panel itself.

Once #544 is merged we can add the camera path button to the Quest/standalone "extras" panel.

I also plan to get rid of the experimental panel and merge the bits we want to keep into other panels but this is a good interim step.