### PR TITLE
Disable mobile bloom for camera snapshots

### DIFF
--- a/Assets/Scripts/ScreenshotManager.cs
+++ b/Assets/Scripts/ScreenshotManager.cs
@@ -205,7 +205,7 @@ namespace TiltBrush
                 var mobileBloom = GetComponent<MobileBloom>();
                 if (mobileBloom != null)
                 {
-                    mobileBloom.enabled = true;
+                    mobileBloom.enabled = false;
                 }
                 else
                 {


### PR DESCRIPTION
Seems to fix the remaining snapshot issue. (Bloom wasn't treated as a post effect by the "disable post fx" user setting - which is why it didn't fix the problem)