### PR TITLE
Update Android SDK Target to v32 (Android 12); request MANAGE_EXTERNAL_STORAGE

### DIFF
--- a/Assets/Plugins/Android/AndroidManifest.xml
+++ b/Assets/Plugins/Android/AndroidManifest.xml
@@ -18,4 +18,5 @@
         <meta-data android:name="unityplayer.SkipPermissionsDialog" android:value="false" />
     </application>
     <uses-permission android:name="android.permission.RECORD_AUDIO" tools:node="remove"/>
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
 </manifest>

--- a/Assets/Scenes/Loading.unity
+++ b/Assets/Scenes/Loading.unity
@@ -206,6 +206,27 @@ MonoBehaviour:
   m_VrCamera: {fileID: 1815664868}
   m_MaximumLoadingTime: 60
   m_SceneLoadRatio: 0.75
+  m_LoadingText:
+    m_TableReference:
+      m_TableCollectionName: GUID:c84355079ab3f3e4f8f3812258805f86
+    m_TableEntryReference:
+      m_KeyId: 287897575133184
+      m_Key: 
+    m_FallbackState: 0
+    m_WaitForCompletion: 0
+    m_LocalVariables: []
+  m_RequestAndroidFolderPermissions:
+    m_TableReference:
+      m_TableCollectionName: GUID:c84355079ab3f3e4f8f3812258805f86
+    m_TableEntryReference:
+      m_KeyId: 170004956477833216
+      m_Key: 
+    m_FallbackState: 0
+    m_WaitForCompletion: 0
+    m_LocalVariables: []
+  references:
+    version: 2
+    RefIds: []
 --- !u!4 &326031496
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/LoadingScene.cs
+++ b/Assets/Scripts/LoadingScene.cs
@@ -123,7 +123,18 @@ namespace TiltBrush
 #if UNITY_ANDROID
         private bool UserHasManageExternalStoragePermission()
         {
-            return m_FolderPermissionOverride || Permission.HasUserAuthorizedPermission("android.permission.MANAGE_EXTERNAL_STORAGE");
+            bool isExternalStorageManager = false;
+            try
+            {
+                AndroidJavaClass environmentClass = new AndroidJavaClass("android.os.Environment");
+                isExternalStorageManager = environmentClass.CallStatic<bool>("isExternalStorageManager");
+            }
+            catch (AndroidJavaException e)
+            {
+                Debug.LogError("Java Exception caught and ignored: " + e.Message);
+                Debug.LogError("Assuming this means this device doesn't support isExternalStorageManager.");
+            }
+            return m_FolderPermissionOverride || isExternalStorageManager;
         }
 
         private void AskForManageStoragePermission()
@@ -144,6 +155,7 @@ namespace TiltBrush
                 // TODO: only skip this if it's of type act=android.settings.MANAGE_APP_ALL_FILES_ACCESS_PERMISSION
                 m_FolderPermissionOverride = true;
                 Debug.LogError("Java Exception caught and ignored: " + e.Message);
+                Debug.LogError("Assuming this means we don't need android.settings.MANAGE_APP_ALL_FILES_ACCESS_PERMISSION (e.g., Android SDK < 30)");
             }
         }
 #endif

--- a/Assets/Settings/Localization/Strings/Strings Shared Data.asset
+++ b/Assets/Settings/Localization/Strings/Strings Shared Data.asset
@@ -540,7 +540,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 287897575133184
-    m_Key: LOADING_SCENE_OVERLAY_MESSAGE
+    m_Key: LOADING_SCENE_OVERLAY_LOADING
     m_Metadata:
       m_Items: []
   - m_Id: 7892854560759808
@@ -3269,6 +3269,10 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 151490030713540608
     m_Key: POPUP_RECORD_UNSUPPORTED_TEXT
+    m_Metadata:
+      m_Items: []
+  - m_Id: 170004956477833216
+    m_Key: LOADING_SCENE_OVERLAY_ANDROIDPERMISSIONS
     m_Metadata:
       m_Items: []
   m_Metadata:

--- a/Assets/Settings/Localization/Strings/Strings_en.asset
+++ b/Assets/Settings/Localization/Strings/Strings_en.asset
@@ -3101,7 +3101,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 106429517453328384
-    m_Localized: "Background Images"
+    m_Localized: Background Images
     m_Metadata:
       m_Items: []
   - m_Id: 95221400803737600
@@ -3457,9 +3457,13 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 151490030713540608
-    m_Localized: 'You can create a video of your sketch by opening it on a Mac or PC.
-      Search for "Exporting video" on our docs website: https://docs.openbrush.app
+    m_Localized: 'You can create a video of your sketch by opening it on a Mac or
+      PC. Search for "Exporting video" on our docs website: https://docs.openbrush.app
       for a step by step guide.'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 170004956477833216
+    m_Localized: Please give Open Brush file access to save your creations!
     m_Metadata:
       m_Items: []
   references:

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -175,8 +175,8 @@ PlayerSettings:
     tvOS: 0
   overrideDefaultApplicationIdentifier: 1
   AndroidBundleVersionCode: 1
-  AndroidMinSdkVersion: 27
-  AndroidTargetSdkVersion: 29
+  AndroidMinSdkVersion: 29
+  AndroidTargetSdkVersion: 32
   AndroidPreferredInstallLocation: 0
   aotOptions: 
   stripEngineCode: 1


### PR DESCRIPTION
Quest submissions now require a target SDK level of 32. We need to use the new storage APIs, however, this is inaccessible on the Quest devices for a variety of reasons, as discussed extensively on Discord. For now, use the file-manager permission of MANAGE_EXTERNAL_STORAGE where available (ignore it if it's not; that probably means a device with an older Android runtime that doesn't need this any way).

Note that on the Q2, after approving the MANAGE_EXTERNAL_STORAGE permission in the (2D) settings app, the Oculus menu bar remains open, although OB loads in the background. To return to our app, the user needs to click on the OB icon and then choose "Resume". This is not the best UX, but it's out of our hands.