### PR TITLE
Enable masking of UNITY_PASSWORD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,8 @@ jobs:
       description: ${{ steps.github.outputs.description}}
       itchchannelname: ${{ steps.version.outputs.itchchannelname }}
     steps:
+      - name: Set masking
+        run: echo "::add-mask::$UNITY_PASSWORD"
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,8 +43,6 @@ jobs:
       description: ${{ steps.github.outputs.description}}
       itchchannelname: ${{ steps.version.outputs.itchchannelname }}
     steps:
-      - name: Set masking
-        run: echo "::add-mask::$UNITY_PASSWORD"
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -213,6 +211,8 @@ jobs:
             extraoptions: -btb-il2cpp -btb-disableAccountLogins
 
     steps:
+      - name: Set masking
+        run: echo "::add-mask::$UNITY_PASSWORD"
       - name: Free extra space
         # This takes several minutes, so we only do it where required. As of 12/10/2023, this increases free space from 18GB to 41GB
         if: matrix.targetPlatform == 'Android' || matrix.targetPlatform == 'StandaloneWindows64'


### PR DESCRIPTION
This is NOT a security feature! The value stored in the file in the clear is still stored there! This merely hides the print in the builder action, making it slightly less obvious. (this only applies to runs from forks; from the repo, it's always masked because it comes from a secret)