### PR TITLE
Quest panel UI fixes

### DIFF
--- a/Assets/Prefabs/Panels/LabsPanel_Mobile.prefab
+++ b/Assets/Prefabs/Panels/LabsPanel_Mobile.prefab
@@ -1147,12 +1147,7 @@ PrefabInstance:
     - target: {fileID: 7020719392467468644, guid: 6e69b3bc22681fb44ac931399886cd69,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.211
-      objectReference: {fileID: 0}
-    - target: {fileID: 7020719392467468644, guid: 6e69b3bc22681fb44ac931399886cd69,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.205
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7020719392467468644, guid: 6e69b3bc22681fb44ac931399886cd69,
         type: 3}

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -29940,9 +29940,9 @@ MonoBehaviour:
       type: 3}
     m_ModeVr: 1
     m_ModeVrExperimental: 1
-    m_ModeQuestExperimental: 0
+    m_ModeQuestExperimental: 1
     m_ModeMono: 1
-    m_ModeQuest: 0
+    m_ModeQuest: 1
     m_ModeGvr: 0
     m_Basic: 0
     m_Advanced: 1


### PR DESCRIPTION
1. Scripts panel button was offset
2. Camera paths is partially supported on Quest after #544 but panel was still hidden