### PR TITLE
Fix Keijiro Tube and mark Race and Digital as "broken" (hidden by default)

### DIFF
--- a/Assets/Resources/X/Brushes/Digital/Digital.asset
+++ b/Assets/Resources/X/Brushes/Digital/Digital.asset
@@ -21,6 +21,7 @@ MonoBehaviour:
   m_Tags:
   - experimental
   - audioreactive
+  - broken
   m_Nondeterministic: 0
   m_Supersedes: {fileID: 0}
   m_LooksIdentical: 0

--- a/Assets/Resources/X/Brushes/KeijiroTube/KeijiroTube.shader
+++ b/Assets/Resources/X/Brushes/KeijiroTube/KeijiroTube.shader
@@ -19,8 +19,7 @@ Properties {
 	_Shininess ("Shininess", Range (0.01, 1)) = 0.078125
 }
     SubShader {
-		LOD 400
-    Cull Back
+        Cull Back
 
 		CGPROGRAM
 		#pragma target 3.0

--- a/Assets/Resources/X/Brushes/KeijiroTube/KeijiroTube.shader
+++ b/Assets/Resources/X/Brushes/KeijiroTube/KeijiroTube.shader
@@ -19,6 +19,7 @@ Properties {
 	_Shininess ("Shininess", Range (0.01, 1)) = 0.078125
 }
     SubShader {
+    	LOD 200
         Cull Back
 
 		CGPROGRAM

--- a/Assets/Resources/X/Brushes/Race/Race.asset
+++ b/Assets/Resources/X/Brushes/Race/Race.asset
@@ -21,6 +21,7 @@ MonoBehaviour:
   m_Tags:
   - experimental
   - audioreactive
+  - broken
   m_Nondeterministic: 0
   m_Supersedes: {fileID: 0}
   m_LooksIdentical: 0


### PR DESCRIPTION
1. Fix Keijiro Tube shader (stopped working after Unity version update presumably)
2. Tag Race and Digital as "broken" so they will be hidden by default