### PR TITLE
Create a distinct Quest 1 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -537,6 +537,10 @@ jobs:
     name: Create Github Release
     needs: [configuration, build]
     runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'push' &&
+      github.repository == 'icosa-foundation/open-brush' &&
+      (github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags/v'))
 
     steps:
       - name: "Build Changelog"
@@ -870,6 +874,10 @@ jobs:
     name: Publish Oculus Quest Release
     needs: [configuration, build]
     runs-on: macos-latest  # the ovr-platform-util tool is only available for Mac and Windows
+    if: |
+      github.event_name == 'push' &&
+      github.repository == 'icosa-foundation/open-brush' &&
+      (github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags/v'))
 
     steps:
       - name: Download Build Artifacts (Oculus Quest 2+)
@@ -907,7 +915,7 @@ jobs:
             ./ovr-platform-util upload-quest-build --app-id ${OCULUS_QUEST_APP_ID} --app-secret ${OCULUS_QUEST_APP_SECRET} --apk OpenBrush_Quest_$VERSION.apk --channel LIVE:quest2+ --debug_symbols_dir ./arm64-v8a/ --debug-symbols-pattern '*.so'
           else
             CHANGELOG="${RAW_CHANGELOG}"
-            ./ovr-platform-util upload-quest-build --app-id ${OCULUS_QUEST_APP_ID} --app-secret ${OCULUS_QUEST_APP_SECRET} --apk OpenBrush_Quest_$VERSION.apk --channel VersionTest:quest2+ --debug_symbols_dir ./arm64-v8a/ --debug-symbols-pattern '*.so' --notes "${CHANGELOG}"
+            ./ovr-platform-util upload-quest-build --app-id ${OCULUS_QUEST_APP_ID} --app-secret ${OCULUS_QUEST_APP_SECRET} --apk OpenBrush_Quest_$VERSION.apk --channel Beta:quest2+ --debug_symbols_dir ./arm64-v8a/ --debug-symbols-pattern '*.so' --notes "${CHANGELOG}"
           fi
           popd
 
@@ -921,7 +929,7 @@ jobs:
             ./ovr-platform-util upload-quest-build --app-id ${OCULUS_QUEST_APP_ID} --app-secret ${OCULUS_QUEST_APP_SECRET} --apk OpenBrush_Quest1_$VERSION.apk --channel LIVE:quest1only --debug_symbols_dir ./arm64-v8a/ --debug-symbols-pattern '*.so'
           else
             CHANGELOG="${RAW_CHANGELOG}"
-            ./ovr-platform-util upload-quest-build --app-id ${OCULUS_QUEST_APP_ID} --app-secret ${OCULUS_QUEST_APP_SECRET} --apk OpenBrush_Quest1_$VERSION.apk --channel VersionTest:quest1only --debug_symbols_dir ./arm64-v8a/ --debug-symbols-pattern '*.so' --notes "${CHANGELOG}"
+            ./ovr-platform-util upload-quest-build --app-id ${OCULUS_QUEST_APP_ID} --app-secret ${OCULUS_QUEST_APP_SECRET} --apk OpenBrush_Quest1_$VERSION.apk --channel Beta:quest1only --debug_symbols_dir ./arm64-v8a/ --debug-symbols-pattern '*.so' --notes "${CHANGELOG}"
           fi
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,7 +206,7 @@ jobs:
             cache: Android_Vulkan
             extraoptions: -btb-il2cpp
             versionSuffix: 0
-            extra_defines: USE_QUEST_PACKAGE_NAME FORCE_QUEST_SUPPORT_DEVICE FORCE_FOCUSAWARE
+            extra_defines: USE_QUEST_PACKAGE_NAME FORCE_QUEST_SUPPORT_DEVICE FORCE_FOCUSAWARE FORCE_HEADTRACKING
             packages_to_remove: com.meta.xr.sdk.platform com.meta.xr.sdk.utilities
 
           - name: Oculus Quest (2+)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version}}
+      androidVersionCode: ${{ steps.version.outputs.androidVersionCode }}
       stamp: ${{ steps.version.outputs.stamp }}
       prerelease: ${{ steps.version.outputs.prerelease }}
       previousrelease: ${{ steps.rawchangelogdata.outputs.previousrelease }}
@@ -93,7 +94,11 @@ jobs:
           VERSION=$(echo "$MAJOR_MINOR.$PATCH_VERSION" | sed -e 's/^v//')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "stamp=$STAMP" >> $GITHUB_OUTPUT
-          echo "Version $VERSION stamp=$STAMP"
+          MAJOR=$(echo $VERSION | cut -d '.' -f 1)
+          MINOR=$(echo $VERSION | cut -d '.' -f 2)
+          ANDROID_VERSION_CODE=$((MAJOR * 1000000 + MINOR * 1000 + PATCH_VERSION))
+          echo "androidVersionCode=$ANDROID_VERSION_CODE" >> $GITHUB_OUTPUT
+          echo "Version $VERSION stamp=$STAMP androidVersionCode=$ANDROID_VERSION_CODE"
       - name: Calculate Release tags for Changelog and raw changelog
         id: rawchangelogdata
         env:
@@ -191,18 +196,21 @@ jobs:
             vrsdk: OpenXR
             cache: Android_Vulkan
             extraoptions: -btb-il2cpp
+            versionSuffix: 0
 
           - name: Oculus Quest
             targetPlatform: Android
             vrsdk: Oculus
             cache: Android_Vulkan
             extraoptions: -btb-il2cpp
+            versionSuffix: 1
 
           - name: Android Pico
             targetPlatform: Android
             vrsdk: Pico
             cache: Android_GLES
             extraoptions: -btb-il2cpp
+            versionSuffix: 0
 
           - name: Android Pico (CN)
             targetPlatform: Android
@@ -210,6 +218,7 @@ jobs:
             cache: Android_GLES
             # Pico requested Chinese build that doesn't have google/sketchfab login.
             extraoptions: -btb-il2cpp -btb-disableAccountLogins
+            versionSuffix: 0
 
     steps:
       - name: Set masking
@@ -398,6 +407,7 @@ jobs:
           targetPlatform: ${{ matrix.targetPlatform }}
           customParameters: -btb-target ${{ matrix.targetPlatform }} -btb-display ${{ matrix.vrsdk }} -btb-out /github/workspace/build/${{ matrix.targetPlatform }}-${{ matrix.vrsdk }}/${{ env.filename }} ${{ needs.configuration.outputs.description}} ${{ env.stamp }} ${{ matrix.extraoptions }}
           versioning: Custom
+          androidVersionCode: "${{ needs.configuration.outputs.androidVersionCode }}${{ matrix.versionSuffix }}"
           version: ${{ needs.configuration.outputs.version }}
           buildMethod: BuildTiltBrush.CommandLine
           androidKeystoreName: openbrush.keystore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,6 +96,11 @@ jobs:
           echo "stamp=$STAMP" >> $GITHUB_OUTPUT
           MAJOR=$(echo $VERSION | cut -d '.' -f 1)
           MINOR=$(echo $VERSION | cut -d '.' -f 2)
+
+          # TODO: for testing only
+          MAJOR=0
+          MINOR=8
+
           ANDROID_VERSION_CODE=$((MAJOR * 1000000 + MINOR * 1000 + PATCH_VERSION))
           echo "androidVersionCode=$ANDROID_VERSION_CODE" >> $GITHUB_OUTPUT
           echo "Version $VERSION stamp=$STAMP androidVersionCode=$ANDROID_VERSION_CODE"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -377,20 +377,15 @@ jobs:
         run: |
           sed -e 's/androidUseCustomKeystore.*$/androidUseCustomKeystore: 1/' -i ProjectSettings/ProjectSettings.asset
 
-      - name: Set OCULUS_SUPPORTED in csc.rsp
-        if: matrix.vrsdk == 'Oculus'
+      - name: Update platform specific defines in csc.rsp
         run: |
-          echo -e "\n-define:OCULUS_SUPPORTED" | tee -a Assets/csc.rsp
-
-      - name: Set PICO_SUPPORTED in csc.rsp
-        if: matrix.vrsdk == 'Pico'
-        run: |
-          echo -e "\n-define:PICO_SUPPORTED" | tee -a Assets/csc.rsp
-
-      - name: Set PIMAX_SUPPORTED in csc.rsp
-        if: matrix.name == 'Windows Pimax'
-        run: |
-          echo -e "\n-define:PIMAX_SUPPORTED" | tee -a Assets/csc.rsp
+          if [[ "${{ matrix.vrsdk }}" == "Oculus" ]]; then
+            echo -e "\n-define:OCULUS_SUPPORTED" | tee -a Assets/csc.rsp
+          elif [[ "${{ matrix.vrsdk }}" == "Pico" ]]; then
+            echo -e "\n-define:PICO_SUPPORTED" | tee -a Assets/csc.rsp
+          elif [[ "${{ matrix.vrsdk }}" == "Oculus" ]]; then
+            echo -e "\n-define:PIMAX_SUPPORTED" | tee -a Assets/csc.rsp
+          fi
 
       - name: Build project
         id: unity_builder

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -594,11 +594,11 @@ jobs:
           name: Windows Monoscopic
           path: build_windows_mono
 
-      - name: Download Build Artifacts (Oculus Quest 1)
+      - name: Download Build Artifacts (Android OpenXR)
         uses: actions/download-artifact@v3
         with:
-          name: Oculus Quest (1)
-          path: build_oculus_quest1
+          name: Android OpenXR
+          path: build_android_openxr
 
       - name: Download Build Artifacts (Oculus Quest 2+)
         uses: actions/download-artifact@v3
@@ -617,8 +617,8 @@ jobs:
           VERSION: ${{ needs.configuration.outputs.version }}
         run: |
           mkdir releases
-          mv build_oculus_quest1/*/com.Icosa.OpenBrush*apk releases/OpenBrush_Quest1_$VERSION.apk
           mv build_oculus_quest/*/com.Icosa.OpenBrush*apk releases/OpenBrush_Quest_$VERSION.apk
+          mv build_android_openxr/*/com.Icosa.OpenBrush*apk releases/OpenBrush_OpenXR_$VERSION.apk
           mv build_android_pico/*/com.Icosa.OpenBrush*apk releases/OpenBrush_Pico_$VERSION.apk
           mv build_windows_openxr/StandaloneWindows64-OpenXR/ releases/OpenBrush_Desktop_$VERSION/
           mv build_windows_rift/StandaloneWindows64-Oculus/ releases/OpenBrush_Rift_$VERSION/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,11 +96,6 @@ jobs:
           echo "stamp=$STAMP" >> $GITHUB_OUTPUT
           MAJOR=$(echo $VERSION | cut -d '.' -f 1)
           MINOR=$(echo $VERSION | cut -d '.' -f 2)
-
-          # TODO: for testing only
-          MAJOR=0
-          MINOR=8
-
           ANDROID_VERSION_CODE=$((MAJOR * 1000000 + MINOR * 1000 + PATCH_VERSION))
           echo "androidVersionCode=$ANDROID_VERSION_CODE" >> $GITHUB_OUTPUT
           echo "Version $VERSION stamp=$STAMP androidVersionCode=$ANDROID_VERSION_CODE"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,6 +207,7 @@ jobs:
             extraoptions: -btb-il2cpp
             versionSuffix: 0
             extra_defines: USE_QUEST_PACKAGE_NAME FORCE_QUEST_SUPPORT_DEVICE FORCE_FOCUSAWARE
+            packages_to_remove: com.meta.xr.sdk.platform com.meta.xr.sdk.utilities
 
           - name: Oculus Quest (2+)
             targetPlatform: Android
@@ -346,6 +347,20 @@ jobs:
           # Some platforms share a cache; it's not a 1:1 mapping of either targetPlatform or vrsdk, so we have a distinct variable for which cache to use
           key: Library_${{ matrix.cache }}_${{ env.UNITY_VERSION }}
 
+      - name: Remove problematic packages
+        if: ${{ matrix.packages_to_remove }}
+        run: |
+          cp Packages/manifest.json{,.bak}
+          cp Packages/packages-lock.json{,.bak}
+          for PACKAGE in ${{ matrix.packages_to_remove }}; do
+            cat Packages/manifest.json | jq 'del( .dependencies ["'${PACKAGE}'"] )' > Packages/manifest.json.new
+            mv Packages/manifest.json.new Packages/manifest.json
+            cat Packages/packages-lock.json | jq 'del( .dependencies ["'${PACKAGE}'"] )' > Packages/packages-lock.json.new
+            mv Packages/packages-lock.json.new Packages/packages-lock.json
+          done
+          diff -u Packages/manifest.json.bak Packages/manifest.json || true
+          diff -u Packages/packages-lock.json.bak Packages/packages-lock.json || true
+
       - name: Restore Library/PackageCache
         id: cache_packagecache
         uses: actions/cache/restore@v3
@@ -478,7 +493,7 @@ jobs:
 
       - name: Save Library/PackageCache cache
         uses: actions/cache/save@v3
-        if: github.ref == 'refs/heads/main' && steps.cache_packagecache.outputs.cache-hit != 'true'  # Ideally, we'd save caches on branches, but they're too big, and branch caches can evict those from main, which is unacceptable.
+        if: github.ref == 'refs/heads/main' && steps.cache_packagecache.outputs.cache-hit != 'true' && ! matrix.packages_to_remove  # Ideally, we'd save caches on branches, but they're too big, and branch caches can evict those from main, which is unacceptable.
         env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 10
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,11 +170,13 @@ jobs:
             targetPlatform: StandaloneWindows64
             vrsdk: OpenXR
             cache: Windows
+            extra_defines: PIMAX_SUPPORTED
 
           - name: Windows Rift
             targetPlatform: StandaloneWindows64
             vrsdk: Oculus
             cache: Windows
+            extra_defines: OCULUS_SUPPORTED
 
           - name: Windows Monoscopic
             targetPlatform: StandaloneWindows64
@@ -198,12 +200,21 @@ jobs:
             extraoptions: -btb-il2cpp
             versionSuffix: 0
 
-          - name: Oculus Quest
+          - name: Oculus Quest (1)
+            targetPlatform: Android
+            vrsdk: OpenXR
+            cache: Android_Vulkan
+            extraoptions: -btb-il2cpp
+            versionSuffix: 0
+            extra_defines: USE_QUEST_PACKAGE_NAME
+
+          - name: Oculus Quest (2+)
             targetPlatform: Android
             vrsdk: Oculus
             cache: Android_Vulkan
             extraoptions: -btb-il2cpp
             versionSuffix: 1
+            extra_defines: OCULUS_SUPPORTED USE_QUEST_PACKAGE_NAME
 
           - name: Android Pico
             targetPlatform: Android
@@ -211,6 +222,7 @@ jobs:
             cache: Android_GLES
             extraoptions: -btb-il2cpp
             versionSuffix: 0
+            extra_defines: PICO_SUPPORTED
 
           - name: Android Pico (CN)
             targetPlatform: Android
@@ -219,6 +231,7 @@ jobs:
             # Pico requested Chinese build that doesn't have google/sketchfab login.
             extraoptions: -btb-il2cpp -btb-disableAccountLogins
             versionSuffix: 0
+            extra_defines: PICO_SUPPORTED
 
     steps:
       - name: Set masking
@@ -386,15 +399,12 @@ jobs:
         run: |
           sed -e 's/androidUseCustomKeystore.*$/androidUseCustomKeystore: 1/' -i ProjectSettings/ProjectSettings.asset
 
-      - name: Update platform specific defines in csc.rsp
+      - name: Update build matrix specific defines in csc.rsp
+        if: ${{ matrix.extra_defines }}
         run: |
-          if [[ "${{ matrix.vrsdk }}" == "Oculus" ]]; then
-            echo -e "\n-define:OCULUS_SUPPORTED" | tee -a Assets/csc.rsp
-          elif [[ "${{ matrix.vrsdk }}" == "Pico" ]]; then
-            echo -e "\n-define:PICO_SUPPORTED" | tee -a Assets/csc.rsp
-          elif [[ "${{ matrix.vrsdk }}" == "Oculus" ]]; then
-            echo -e "\n-define:PIMAX_SUPPORTED" | tee -a Assets/csc.rsp
-          fi
+          for DEFINE in ${{ matrix.extra_defines }}; do
+            echo -e "\n-define:$DEFINE" | tee -a Assets/csc.rsp
+          done
 
       - name: Build project
         id: unity_builder
@@ -569,10 +579,16 @@ jobs:
           name: Windows Monoscopic
           path: build_windows_mono
 
-      - name: Download Build Artifacts (Oculus Quest)
+      - name: Download Build Artifacts (Oculus Quest 1)
         uses: actions/download-artifact@v3
         with:
-          name: Oculus Quest
+          name: Oculus Quest (1)
+          path: build_oculus_quest1
+
+      - name: Download Build Artifacts (Oculus Quest 2+)
+        uses: actions/download-artifact@v3
+        with:
+          name: Oculus Quest (2+)
           path: build_oculus_quest
 
       - name: Download Build Artifacts (Pico)
@@ -586,6 +602,7 @@ jobs:
           VERSION: ${{ needs.configuration.outputs.version }}
         run: |
           mkdir releases
+          mv build_oculus_quest1/*/com.Icosa.OpenBrush*apk releases/OpenBrush_Quest1_$VERSION.apk
           mv build_oculus_quest/*/com.Icosa.OpenBrush*apk releases/OpenBrush_Quest_$VERSION.apk
           mv build_android_pico/*/com.Icosa.OpenBrush*apk releases/OpenBrush_Pico_$VERSION.apk
           mv build_windows_openxr/StandaloneWindows64-OpenXR/ releases/OpenBrush_Desktop_$VERSION/
@@ -811,10 +828,10 @@ jobs:
           name: Windows OpenXR
           path: build_windows_openxr
 
-      - name: Download Build Artifacts (Oculus Quest)
+      - name: Download Build Artifacts (Oculus Quest 2+)
         uses: actions/download-artifact@v3
         with:
-          name: Oculus Quest
+          name: Oculus Quest (2+)
           path: build_oculus_quest
 
       - name: Package Artifacts for release
@@ -843,11 +860,16 @@ jobs:
       (github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags/v'))
 
     steps:
-      - name: Download Build Artifacts (Oculus Quest)
+      - name: Download Build Artifacts (Oculus Quest 2+)
         uses: actions/download-artifact@v3
         with:
-          name: Oculus Quest
+          name: Oculus Quest (2+)
           path: build_oculus_quest
+      - name: Download Build Artifacts (Oculus Quest 1)
+        uses: actions/download-artifact@v3
+        with:
+          name: Oculus Quest (1)
+          path: build_oculus_quest1
       - name: Publish Oculus Builds
         env:
           VERSION: ${{ needs.configuration.outputs.version }}
@@ -859,18 +881,37 @@ jobs:
           mkdir releases
           mv build_oculus_quest/*/com.Icosa.OpenBrush*apk releases/OpenBrush_Quest_$VERSION.apk
           mv build_oculus_quest/*/com.Icosa.OpenBrush*.symbols.zip releases/symbols.zip
-          cd releases
+          mkdir releases1
+          mv build_oculus_quest1/*/com.Icosa.OpenBrush*apk releases1/OpenBrush_Quest1_$VERSION.apk
+          mv build_oculus_quest1/*/com.Icosa.OpenBrush*.symbols.zip releases1/symbols.zip
+
+          pushd releases
           unzip symbols.zip
           curl -L 'https://www.oculus.com/download_app/?id=1462426033810370' -o ovr-platform-util
           chmod 755 ovr-platform-util
 
           if [ "$PRERELEASE" == "false" ]
           then
-            ./ovr-platform-util upload-quest-build --app-id ${OCULUS_QUEST_APP_ID} --app-secret ${OCULUS_QUEST_APP_SECRET} --apk OpenBrush_Quest_$VERSION.apk --channel LIVE --debug_symbols_dir ./arm64-v8a/ --debug-symbols-pattern '*.so'
+            ./ovr-platform-util upload-quest-build --app-id ${OCULUS_QUEST_APP_ID} --app-secret ${OCULUS_QUEST_APP_SECRET} --apk OpenBrush_Quest_$VERSION.apk --channel LIVE:quest2+ --debug_symbols_dir ./arm64-v8a/ --debug-symbols-pattern '*.so'
           else
             CHANGELOG="${RAW_CHANGELOG}"
-            ./ovr-platform-util upload-quest-build --app-id ${OCULUS_QUEST_APP_ID} --app-secret ${OCULUS_QUEST_APP_SECRET} --apk OpenBrush_Quest_$VERSION.apk --channel Beta --debug_symbols_dir ./arm64-v8a/ --debug-symbols-pattern '*.so' --notes "${CHANGELOG}"
+            ./ovr-platform-util upload-quest-build --app-id ${OCULUS_QUEST_APP_ID} --app-secret ${OCULUS_QUEST_APP_SECRET} --apk OpenBrush_Quest_$VERSION.apk --channel Beta:quest2+ --debug_symbols_dir ./arm64-v8a/ --debug-symbols-pattern '*.so' --notes "${CHANGELOG}"
           fi
+          popd
+
+          pushd releases1
+          unzip symbols.zip
+          curl -L 'https://www.oculus.com/download_app/?id=1462426033810370' -o ovr-platform-util
+          chmod 755 ovr-platform-util
+
+          if [ "$PRERELEASE" == "false" ]
+          then
+            ./ovr-platform-util upload-quest-build --app-id ${OCULUS_QUEST_APP_ID} --app-secret ${OCULUS_QUEST_APP_SECRET} --apk OpenBrush_Quest1_$VERSION.apk --channel LIVE:quest1only --debug_symbols_dir ./arm64-v8a/ --debug-symbols-pattern '*.so'
+          else
+            CHANGELOG="${RAW_CHANGELOG}"
+            ./ovr-platform-util upload-quest-build --app-id ${OCULUS_QUEST_APP_ID} --app-secret ${OCULUS_QUEST_APP_SECRET} --apk OpenBrush_Quest1_$VERSION.apk --channel Beta:quest1only --debug_symbols_dir ./arm64-v8a/ --debug-symbols-pattern '*.so' --notes "${CHANGELOG}"
+          fi
+
 
   publish_oculus_rift:
     name: Publish Oculus Rift Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -537,10 +537,6 @@ jobs:
     name: Create Github Release
     needs: [configuration, build]
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'push' &&
-      github.repository == 'icosa-foundation/open-brush' &&
-      (github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags/v'))
 
     steps:
       - name: "Build Changelog"
@@ -874,10 +870,6 @@ jobs:
     name: Publish Oculus Quest Release
     needs: [configuration, build]
     runs-on: macos-latest  # the ovr-platform-util tool is only available for Mac and Windows
-    if: |
-      github.event_name == 'push' &&
-      github.repository == 'icosa-foundation/open-brush' &&
-      (github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags/v'))
 
     steps:
       - name: Download Build Artifacts (Oculus Quest 2+)
@@ -915,7 +907,7 @@ jobs:
             ./ovr-platform-util upload-quest-build --app-id ${OCULUS_QUEST_APP_ID} --app-secret ${OCULUS_QUEST_APP_SECRET} --apk OpenBrush_Quest_$VERSION.apk --channel LIVE:quest2+ --debug_symbols_dir ./arm64-v8a/ --debug-symbols-pattern '*.so'
           else
             CHANGELOG="${RAW_CHANGELOG}"
-            ./ovr-platform-util upload-quest-build --app-id ${OCULUS_QUEST_APP_ID} --app-secret ${OCULUS_QUEST_APP_SECRET} --apk OpenBrush_Quest_$VERSION.apk --channel Beta:quest2+ --debug_symbols_dir ./arm64-v8a/ --debug-symbols-pattern '*.so' --notes "${CHANGELOG}"
+            ./ovr-platform-util upload-quest-build --app-id ${OCULUS_QUEST_APP_ID} --app-secret ${OCULUS_QUEST_APP_SECRET} --apk OpenBrush_Quest_$VERSION.apk --channel VersionTest:quest2+ --debug_symbols_dir ./arm64-v8a/ --debug-symbols-pattern '*.so' --notes "${CHANGELOG}"
           fi
           popd
 
@@ -929,7 +921,7 @@ jobs:
             ./ovr-platform-util upload-quest-build --app-id ${OCULUS_QUEST_APP_ID} --app-secret ${OCULUS_QUEST_APP_SECRET} --apk OpenBrush_Quest1_$VERSION.apk --channel LIVE:quest1only --debug_symbols_dir ./arm64-v8a/ --debug-symbols-pattern '*.so'
           else
             CHANGELOG="${RAW_CHANGELOG}"
-            ./ovr-platform-util upload-quest-build --app-id ${OCULUS_QUEST_APP_ID} --app-secret ${OCULUS_QUEST_APP_SECRET} --apk OpenBrush_Quest1_$VERSION.apk --channel Beta:quest1only --debug_symbols_dir ./arm64-v8a/ --debug-symbols-pattern '*.so' --notes "${CHANGELOG}"
+            ./ovr-platform-util upload-quest-build --app-id ${OCULUS_QUEST_APP_ID} --app-secret ${OCULUS_QUEST_APP_SECRET} --apk OpenBrush_Quest1_$VERSION.apk --channel VersionTest:quest1only --debug_symbols_dir ./arm64-v8a/ --debug-symbols-pattern '*.so' --notes "${CHANGELOG}"
           fi
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -333,33 +333,19 @@ jobs:
           path: Library/PackageCache
           key: Library_PackageCache_${{ env.UNITY_VERSION }}
 
-      - name: Set filename (for Windows)
-        if: matrix.targetPlatform == 'StandaloneWindows64'
+      - name: Set output filename
         env:
           BASENAME: ${{ needs.configuration.outputs.basename}}
-        run:
-          echo "filename=$BASENAME.exe" >> $GITHUB_ENV
-
-      - name: Set filename (for Linux)
-        if: matrix.targetPlatform == 'StandaloneLinux64'
-        env:
-          BASENAME: ${{ needs.configuration.outputs.basename}}
-        run:
-          echo "filename=$BASENAME" >> $GITHUB_ENV
-
-      - name: Set filename (for OSX)
-        if: matrix.targetPlatform == 'StandaloneOSX'
-        env:
-          BASENAME: ${{ needs.configuration.outputs.basename}}
-        run:
-          echo "filename=$BASENAME.app" >> $GITHUB_ENV
-
-      - name: Set filename (for Android)
-        if: matrix.targetPlatform == 'Android'
-        env:
-          BASENAME: ${{ needs.configuration.outputs.basename}}
-        run:
-          echo "filename=com.Icosa.$BASENAME.apk" >> $GITHUB_ENV
+        run: |
+          if [[ "${{ matrix.targetPlatform}}" == "StandaloneWindows64" ]]; then
+            echo "filename=$BASENAME.exe" >> $GITHUB_ENV
+          elif [[ "${{ matrix.targetPlatform}}" == "StandaloneLinux64" ]]; then
+            echo "filename=$BASENAME" >> $GITHUB_ENV
+          elif [[ "${{ matrix.targetPlatform}}" == "StandaloneOSX" ]]; then
+            echo "filename=$BASENAME.app" >> $GITHUB_ENV
+          elif [[ "${{ matrix.targetPlatform}}" == "Android" ]]; then
+            echo "filename=com.Icosa.$BASENAME.apk" >> $GITHUB_ENV
+          fi
 
       - name: Set build stamp
         if: ${{ needs.configuration.outputs.stamp }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,7 +206,7 @@ jobs:
             cache: Android_Vulkan
             extraoptions: -btb-il2cpp
             versionSuffix: 0
-            extra_defines: USE_QUEST_PACKAGE_NAME
+            extra_defines: USE_QUEST_PACKAGE_NAME FORCE_QUEST_SUPPORT_DEVICE FORCE_FOCUSAWARE
 
           - name: Oculus Quest (2+)
             targetPlatform: Android

--- a/Assets/Editor/BuildTiltBrush.cs
+++ b/Assets/Editor/BuildTiltBrush.cs
@@ -41,6 +41,7 @@ using Environment = System.Environment;
 //----------------------------------------------------------------------------------------
 // All output from this class is prefixed with "_btb_" to facilitate extracting
 // it from Unity's very noisy and spammy Editor.log file.
+
 static class BuildTiltBrush
 {
     // Types, consts, enums
@@ -968,7 +969,7 @@ static class BuildTiltBrush
             m_company = PlayerSettings.companyName;
             string new_name = App.kAppDisplayName;
             string new_identifier = GuiBuildAndroidApplicationIdentifier;
-#if OCULUS_SUPPORTED
+#if OCULUS_SUPPORTED || USE_QUEST_PACKAGE_NAME
             //Can't change Quest identifier
             new_identifier = "com.Icosa.OpenBrush";
 #endif

--- a/Assets/Editor/BuildTiltBrush.cs
+++ b/Assets/Editor/BuildTiltBrush.cs
@@ -976,7 +976,7 @@ static class BuildTiltBrush
             if (!String.IsNullOrEmpty(Description))
             {
                 new_name += " (" + Description + ")";
-                // new_identifier += Description.Replace("_", "").Replace("#", "").Replace("-", "");
+                new_identifier += Description.Replace("_", "").Replace("#", "").Replace("-", "");
             }
             if (m_isAndroid)
             {

--- a/Assets/Editor/BuildTiltBrush.cs
+++ b/Assets/Editor/BuildTiltBrush.cs
@@ -976,7 +976,7 @@ static class BuildTiltBrush
             if (!String.IsNullOrEmpty(Description))
             {
                 new_name += " (" + Description + ")";
-                new_identifier += Description.Replace("_", "").Replace("#", "").Replace("-", "");
+                // new_identifier += Description.Replace("_", "").Replace("#", "").Replace("-", "");
             }
             if (m_isAndroid)
             {

--- a/Assets/Editor/BuildTiltBrushPostProcess.cs
+++ b/Assets/Editor/BuildTiltBrushPostProcess.cs
@@ -43,7 +43,8 @@ public class BuildTiltBrushPostProcess
 
 
 
-            UnityEngine.Debug.Log("Add all quest supported devices.");
+#if FORCE_QUEST_SUPPORT_DEVICE
+            UnityEngine.Debug.Log("Add quest as a supported devices");
             AddOrRemoveTag(doc,
                 androidNamespaceURI,
                 "/manifest/application",
@@ -51,9 +52,12 @@ public class BuildTiltBrushPostProcess
                 "com.oculus.supportedDevices",
                 true,
                 true,
-                "value", "quest|quest2"
+                "value", "quest"
             );
+#endif
 
+#if FORCE_FOCUSAWARE
+            UnityEngine.Debug.Log("Add com.oculus.vr.focusaware");
             AddOrRemoveTag(doc,
                 androidNamespaceURI,
                 "/manifest/application/activity",
@@ -63,6 +67,7 @@ public class BuildTiltBrushPostProcess
                 true,
                 "value", "true"
             );
+#endif
 
             doc.Save(file);
         }

--- a/Assets/Editor/BuildTiltBrushPostProcess.cs
+++ b/Assets/Editor/BuildTiltBrushPostProcess.cs
@@ -69,6 +69,20 @@ public class BuildTiltBrushPostProcess
             );
 #endif
 
+#if FORCE_HEADTRACKING
+            UnityEngine.Debug.Log("Add android.hardware.vr.headtracking");
+            AddOrRemoveTag(doc,
+                    androidNamespaceURI,
+                    "/manifest",
+                    "uses-feature",
+                    "android.hardware.vr.headtracking",
+                    true,
+                    true,
+                    "version", "1",
+                    "required", "true"
+            );
+#endif
+
             doc.Save(file);
         }
         catch (System.Exception e)

--- a/Assets/Editor/BuildTiltBrushPostProcess.cs
+++ b/Assets/Editor/BuildTiltBrushPostProcess.cs
@@ -54,6 +54,16 @@ public class BuildTiltBrushPostProcess
                 "value", "quest|quest2"
             );
 
+            AddOrRemoveTag(doc,
+                androidNamespaceURI,
+                "/manifest/application/activity",
+                "meta-data",
+                "com.oculus.vr.focusaware",
+                true,
+                true,
+                "value", "true"
+            );
+
             doc.Save(file);
         }
         catch (System.Exception e)

--- a/Assets/OculusMR/AnchorToGuide.cs
+++ b/Assets/OculusMR/AnchorToGuide.cs
@@ -21,7 +21,7 @@ namespace TiltBrush
     public class AnchorToGuide : MonoBehaviour
     {
         // Start is called before the first frame update
-
+#if OCULUS_SUPPORTED
         private OVRSceneVolume m_SceneComponentVolume;
         private OVRScenePlane m_SceneComponentPlane;
         private OVRSemanticClassification m_Classification;
@@ -69,6 +69,7 @@ namespace TiltBrush
             //     return;
             // }
         }
+#endif // OCULUS_SUPPORTED
     }
 
 }

--- a/Assets/OculusMR/OculusMRController.cs
+++ b/Assets/OculusMR/OculusMRController.cs
@@ -21,6 +21,7 @@ namespace TiltBrush
 {
     public class OculusMRController : MonoBehaviour
     {
+#if OCULUS_SUPPORTED
         public static OculusMRController m_Instance;
 
         public OVRSceneManager ovrSceneManager;
@@ -74,6 +75,7 @@ namespace TiltBrush
                 loadedScene = true;
             }
         }
+#endif // OCULUS_SUPPORTED
     }
 }
 

--- a/Assets/OculusMR/SpatialAnchorManager.cs
+++ b/Assets/OculusMR/SpatialAnchorManager.cs
@@ -22,6 +22,7 @@ namespace TiltBrush
 {
     public class SpatialAnchorManager : MonoBehaviour
     {
+#if OCULUS_SUPPORTED
         const string kOriginSpatialAnchorPref = "ORIGIN_SPATIAL_ANCHOR";
 
         OVRSpatialAnchor m_Anchor;
@@ -185,5 +186,6 @@ namespace TiltBrush
 
             return false;
         }
+#endif // OCULUS_SUPPORTED
     }
 }

--- a/Assets/Scripts/Config.cs
+++ b/Assets/Scripts/Config.cs
@@ -498,6 +498,7 @@ namespace TiltBrush
         {
             get => PlayerPrefs.HasKey("ExperimentalMode") && PlayerPrefs.GetInt("ExperimentalMode") == 1;
         }
+
         public bool GeometryShaderSuppported
         {
             get
@@ -506,7 +507,7 @@ namespace TiltBrush
                 SystemHeadset headset = Unity.XR.Oculus.Utils.GetSystemHeadsetType();
                 return headset != SystemHeadset.Oculus_Quest;
 #endif
-                return true;
+                return SystemInfo.supportsGeometryShaders;
             }
         }
 

--- a/Assets/Scripts/Multiplayer/MultiplayerManager.cs
+++ b/Assets/Scripts/Multiplayer/MultiplayerManager.cs
@@ -16,7 +16,9 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 using Unity.XR.CoreUtils;
+#if OCULUS_SUPPORTED
 using OVRPlatform = Oculus.Platform;
+#endif
 using TiltBrush;
 
 namespace OpenBrush.Multiplayer
@@ -210,6 +212,7 @@ namespace OpenBrush.Multiplayer
 
         async void ShareAnchors()
         {
+#if OCULUS_SUPPORTED
             Debug.Log($"sharing to {oculusPlayerIds.Count} Ids");
             var success = await OculusMRController.m_Instance.m_SpatialAnchorManager.ShareAnchors(oculusPlayerIds);
 
@@ -220,6 +223,7 @@ namespace OpenBrush.Multiplayer
                     await m_Manager.RpcSyncToSharedAnchor(OculusMRController.m_Instance.m_SpatialAnchorManager.AnchorUuid);
                 }
             }
+#endif // OCULUS_SUPPORTED
         }
     }
 }

--- a/Assets/Scripts/Multiplayer/Photon/PhotonRPC.cs
+++ b/Assets/Scripts/Multiplayer/Photon/PhotonRPC.cs
@@ -156,7 +156,9 @@ namespace OpenBrush.Multiplayer
         [Rpc(InvokeLocal = false)]
         public static void RPC_SyncToSharedAnchor(NetworkRunner runner, string uuid)
         {
+#if OCULUS_SUPPORTED
             OculusMRController.m_Instance.RemoteSyncToAnchor(uuid);
+#endif // OCULUS_SUPPORTED
         }
 
         [Rpc(InvokeLocal = false)]


### PR DESCRIPTION
In order to prepare for MR multiplayer, in #578 , we had to upgrade the Oculus plugins to a version greater than v50, which drops support for Q1. To continue to support Q1, we'll have a distinct build for the original quest, and upload it using Oculus's new(ish) device specific targeting.

Notes:

1. The build action was refactored to remove steps that represented special cases, and to have everything driven from the matrix. This will make things easier to extend (but will cause a small conflict with #556 ).
2. Despite what the docs implied, even if two builds will never be on the same device, Oculus won't let them share a Version Code. To mitigate this, this PR changes the logic from `versionCode = MAJOR * 1000000 + MINOR * 1000 + PATCH` to `versionCode = oldVersionCodeLogic * 10 + SUFFIX`, where `SUFFIX` is either 0 (for most platforms) or 1 (for Oculus Quest 2+).
3. The Q1 build is now the default Android OpenXR build, with some Quest specific stuff in the manifest. 
4. In order to be accepted by Meta, we need to completely remove the meta.* packages prior to building. Even if we don't use the plugin. Ugh. 
5. Because it's no longer using OVR, we need to tell it to use the other shaders by checking `SystemInfo.supportsGeometryShaders`
