### PR TITLE
Don't include the _BackUpThisFolder_ButDontShipItWithYourGame folder in the artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -491,7 +491,7 @@ jobs:
           name: ${{ matrix.name }}
           path: |
             build
-            !build/*_BackUpThisFolder_ButDontShipItWithYourGame
+            !build/**/*_BackUpThisFolder_ButDontShipItWithYourGame
 
       - name: Save Library/PackageCache cache
         uses: actions/cache/save@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -489,7 +489,9 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.name }}
-          path: build
+          path: |
+            build
+            !build/*_BackUpThisFolder_ButDontShipItWithYourGame
 
       - name: Save Library/PackageCache cache
         uses: actions/cache/save@v3


### PR DESCRIPTION
We have no way to get core dumps from users in any case, so there's no need to save this. Until github's upload-artifacts fixes their slow performance, this should save about 5 minutes in upload/download time.