### PR TITLE
Set TrackingOrigin to Stage

### DIFF
--- a/Assets/Scripts/VrSdk.cs
+++ b/Assets/Scripts/VrSdk.cs
@@ -173,7 +173,7 @@ namespace TiltBrush
             // OculusVR
             // ---------------------------------------------------------------------------------------- //
             OVRManager manager = gameObject.AddComponent<OVRManager>();
-            manager.trackingOriginType = OVRManager.TrackingOrigin.FloorLevel;
+            manager.trackingOriginType = OVRManager.TrackingOrigin.Stage;
             manager.useRecommendedMSAALevel = false;
             manager.isInsightPassthroughEnabled = true;
 


### PR DESCRIPTION
Prevents the world shifting every time the Quest hmd is removed. Seems fairly consistent from my test.