### PR TITLE
Don't allow selection of media widgets if not on the active layer

### DIFF
--- a/Assets/Scripts/SketchControlsScript.cs
+++ b/Assets/Scripts/SketchControlsScript.cs
@@ -2353,10 +2353,16 @@ namespace TiltBrush
             GrabWidgetData best = null;
             for (int i = 0; i < candidates.Count; ++i)
             {
-                if (candidates[i].m_NearController &&
-                    (best == null || candidates[i].m_ControllerScore > best.m_ControllerScore))
+                var candidate = candidates[i];
+                if (!candidate.m_NearController) continue;
+
+                // For media widgets - only select from the active layer
+                if (candidate.m_WidgetScript is MediaWidget
+                    && candidate.m_WidgetScript.Canvas != App.Scene.ActiveCanvas) continue;
+
+                if (best == null || candidate.m_ControllerScore > best.m_ControllerScore)
                 {
-                    best = candidates[i];
+                    best = candidate;
                 }
             }
             return best;


### PR DESCRIPTION
This is now consistent with how the selection tool behaves. 

Open questions:

1. Should guides and camera paths also respect layers?
2. Should this behavior be switchable? i.e. an explicit "lock" icon on the Layers Panel