### PR TITLE
Reset orientation settings

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -8,7 +8,7 @@ PlayerSettings:
   AndroidProfiler: 0
   AndroidFilterTouchesWhenObscured: 0
   AndroidEnableSustainedPerformanceMode: 0
-  defaultScreenOrientation: 4
+  defaultScreenOrientation: 3
   targetDevice: 2
   useOnDemandResources: 0
   accelerometerFrequency: 100


### PR DESCRIPTION
Should fix the issue with Quest 1, will need to find a better fix for changing this on Zapbox.

Fixes an issue introduced in #556 