### PR TITLE
Feature/sketchfab improvements

### DIFF
--- a/Assets/Prefabs/Accounts/Authentication/ReplaceHeadset.html
+++ b/Assets/Prefabs/Accounts/Authentication/ReplaceHeadset.html
@@ -3,7 +3,7 @@
 
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head profile="http://www.w3.org/2005/10/profile">
-    <title>Tilt Brush - Replace your headset</title>
+    <title>Open Brush - Replace your headset</title>
     <link href="https://fonts.googleapis.com/css?family=Roboto&display=swap" rel="stylesheet">
     <link rel="icon" type="image/png" href="TiltBrush_FavIcon.png" />
     <style>
@@ -21,7 +21,7 @@
   <body>
     <div>
       <img src="TiltasaurusHMDOn.png"/><br/>
-      Put your headset on to return to Tilt Brush<br/>
+      Put your headset on to return to Open Brush<br/>
       and continue creating.
     </div>
   </body>

--- a/Assets/Prefabs/Accounts/Authentication/ReplaceHeadsetMobile.html
+++ b/Assets/Prefabs/Accounts/Authentication/ReplaceHeadsetMobile.html
@@ -3,7 +3,7 @@
 
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head profile="http://www.w3.org/2005/10/profile">
-    <title>Tilt Brush - Replace your headset</title>
+    <title>Open Brush - Replace your headset</title>
     <link href="https://fonts.googleapis.com/css?family=Roboto&display=swap" rel="stylesheet">
     <link rel="icon" type="image/png" href="TiltBrush_FavIcon.png" />
     <style>
@@ -21,7 +21,8 @@
   <body>
     <div>
       <img src="TiltasaurusHMDOn.png" width=384 height=384/><br/>
-      Relaunch Tilt Brush to continue creating.
+      Return to Open Brush to continue creating.<br/>
+      Meta Quest users can click the "Done" button above.
     </div>
   </body>
 </html>

--- a/Assets/Prefabs/PopUps/PopupWindow_UploadMobile.prefab
+++ b/Assets/Prefabs/PopUps/PopupWindow_UploadMobile.prefab
@@ -1003,7 +1003,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1000013096383082, guid: 4d2503fe0d5c9ae48a510658ac9df4a9, type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1000013114340806, guid: 4d2503fe0d5c9ae48a510658ac9df4a9, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1000014041336086, guid: 4d2503fe0d5c9ae48a510658ac9df4a9, type: 3}
       propertyPath: m_IsActive
@@ -1053,6 +1057,27 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 34748761131250936, guid: 4d2503fe0d5c9ae48a510658ac9df4a9,
+        type: 3}
+      propertyPath: m_text
+      value: Free Sketchfab accounts can't publish  Private models. If you see error
+        403 when publishing check your visibility settings.
+      objectReference: {fileID: 0}
+    - target: {fileID: 34748761131250936, guid: 4d2503fe0d5c9ae48a510658ac9df4a9,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 34748761131250936, guid: 4d2503fe0d5c9ae48a510658ac9df4a9,
+        type: 3}
+      propertyPath: m_margin.w
+      value: -0.2722435
+      objectReference: {fileID: 0}
+    - target: {fileID: 34748761131250936, guid: 4d2503fe0d5c9ae48a510658ac9df4a9,
+        type: 3}
+      propertyPath: m_fontSizeBase
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 612561239130847434, guid: 4d2503fe0d5c9ae48a510658ac9df4a9,
         type: 3}
       propertyPath: m_text
@@ -1066,7 +1091,17 @@ PrefabInstance:
     - target: {fileID: 970682864746106188, guid: 4d2503fe0d5c9ae48a510658ac9df4a9,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1946674739864310761, guid: 4d2503fe0d5c9ae48a510658ac9df4a9,
+        type: 3}
+      propertyPath: managedReferences[3215294302546034713].m_Localized.m_TableEntryReference.m_KeyId
+      value: 189087250755706880
+      objectReference: {fileID: 0}
+    - target: {fileID: 5173511161803795244, guid: 4d2503fe0d5c9ae48a510658ac9df4a9,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0.3
       objectReference: {fileID: 0}
     - target: {fileID: 5386564173593758542, guid: 4d2503fe0d5c9ae48a510658ac9df4a9,
         type: 3}

--- a/Assets/Prefabs/PopUps/PopupWindow_UploadMobile.prefab
+++ b/Assets/Prefabs/PopUps/PopupWindow_UploadMobile.prefab
@@ -539,7 +539,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Exit Open Brush
+  m_text: Click to Finish Publishing
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: fce54057bad3d2d4cb3c36ee394be518, type: 2}
   m_sharedMaterial: {fileID: 2133298, guid: fce54057bad3d2d4cb3c36ee394be518, type: 2}
@@ -1060,8 +1060,8 @@ PrefabInstance:
     - target: {fileID: 34748761131250936, guid: 4d2503fe0d5c9ae48a510658ac9df4a9,
         type: 3}
       propertyPath: m_text
-      value: Free Sketchfab accounts can't publish  Private models. If you see error
-        403 when publishing check your visibility settings.
+      value: To avoid error 403 on Sketchfab when publishing - change visibility
+        to public (free Sketchfab accounts can't publish private models)
       objectReference: {fileID: 0}
     - target: {fileID: 34748761131250936, guid: 4d2503fe0d5c9ae48a510658ac9df4a9,
         type: 3}
@@ -1097,6 +1097,11 @@ PrefabInstance:
         type: 3}
       propertyPath: managedReferences[3215294302546034713].m_Localized.m_TableEntryReference.m_KeyId
       value: 189087250755706880
+      objectReference: {fileID: 0}
+    - target: {fileID: 5173511161803795244, guid: 4d2503fe0d5c9ae48a510658ac9df4a9,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.0035
       objectReference: {fileID: 0}
     - target: {fileID: 5173511161803795244, guid: 4d2503fe0d5c9ae48a510658ac9df4a9,
         type: 3}

--- a/Assets/Scripts/Sharing/HttpServer.cs
+++ b/Assets/Scripts/Sharing/HttpServer.cs
@@ -26,7 +26,7 @@ using UnityEngine;
 
 namespace TiltBrush
 {
-    /// Class for responding to Http Requests. request handlers can be added for specfic paths.
+    /// Class for responding to Http Requests. request handlers can be added for specific paths.
     public class HttpServer : MonoBehaviour
     {
         [SerializeField] private int m_httpListenerPort = 40074;
@@ -146,7 +146,7 @@ namespace TiltBrush
 
         /// Adds a handler to the Http server that responds to a given path.
         /// Path should include / at the start - e.g. /load  /files  /pages  etc
-        /// The function takes a request and should return its response as an html string. 
+        /// The function takes a request and should return its response as an html string.
         /// The response does not need to be closed.
         public void AddHttpHandler(string path, Func<HttpListenerRequest, string> handler)
         {

--- a/Assets/Settings/Localization/Strings/Strings Shared Data.asset
+++ b/Assets/Settings/Localization/Strings/Strings Shared Data.asset
@@ -3279,6 +3279,10 @@ MonoBehaviour:
     m_Key: CONTROLLER_HINT_THUMBPAD_BRUSHSIZE
     m_Metadata:
       m_Items: []
+  - m_Id: 189087250755706880
+    m_Key: POPUP_UPLOAD_COMPLETE_MOBILE_DESCRIPTION
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/Assets/Settings/Localization/Strings/Strings_en.asset
+++ b/Assets/Settings/Localization/Strings/Strings_en.asset
@@ -1433,7 +1433,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 76086604699590656
-    m_Localized: Uploaded as Draft. Click to Finish Publishing
+    m_Localized: Click to Finish Publishing
     m_Metadata:
       m_Items: []
   - m_Id: 76094622149435392
@@ -3473,8 +3473,8 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 189087250755706880
-    m_Localized: Free Sketchfab accounts can't publish  Private models. If you see
-      error 403 when publishing check your visibility settings.
+    m_Localized: To avoid error 403 on Sketchfab when publishing - change visibility
+      to public (free Sketchfab accounts can't publish private models)
     m_Metadata:
       m_Items: []
   references:

--- a/Assets/Settings/Localization/Strings/Strings_en.asset
+++ b/Assets/Settings/Localization/Strings/Strings_en.asset
@@ -1433,7 +1433,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 76086604699590656
-    m_Localized: Exit Open Brush to finish publishing
+    m_Localized: Uploaded as Draft. Click to Finish Publishing
     m_Metadata:
       m_Items: []
   - m_Id: 76094622149435392

--- a/Assets/Settings/Localization/Strings/Strings_en.asset
+++ b/Assets/Settings/Localization/Strings/Strings_en.asset
@@ -3472,6 +3472,11 @@ MonoBehaviour:
       Brush Size'
     m_Metadata:
       m_Items: []
+  - m_Id: 189087250755706880
+    m_Localized: Free Sketchfab accounts can't publish  Private models. If you see
+      error 403 when publishing check your visibility settings.
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []


### PR DESCRIPTION
Wording changes related to login and upload.

Outstanding issue:

We default to exporting as "private" with Sketchfab. However this requires a paying account.

Sketchfab has no meaningful error message when the user tries to publish as "private" on a free account (You just get some text about a 403 error).

Most users will assume this is something they cannot fix themselves. I propose we change the default to "public" and add some text somewhere telling people to change it if they have a paid account.