### PR TITLE
Use Mac OS 13 instead of latest (currently 12) when pushing iOS builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1175,7 +1175,7 @@ jobs:
   publish_ios_zapbox:
     name: Publish Zapbox iOS
     needs: [configuration, build]
-    runs-on: macos-latest
+    runs-on: macos-13  # As of 2024-03-01, macos-latest still points to Mac OS 12, which has an older XCode and gives ITMS-90725: SDK version issue when we submit.
     if: |
       github.event_name == 'push' &&
       github.repository == 'icosa-foundation/open-brush' &&


### PR DESCRIPTION
Running on the current default of macos-latest, we get this message from the App Store via email:

Although delivery was successful, you may want to correct the following issues in your next delivery. Once you've corrected the issues, upload a new binary to App Store Connect.

ITMS-90725: SDK version issue - This app was built with the iOS 16.2 SDK. Starting April 29, 2024, all iOS and iPadOS apps must be built with the iOS 17 SDK or later, included in Xcode 15 or later, in order to be uploaded to App Store Connect or submitted for distribution.