### PR TITLE
Fix issue where transparent brushes were invisible in Quest passthrough mode.

### DIFF
--- a/Assets/Scripts/VrSdk.cs
+++ b/Assets/Scripts/VrSdk.cs
@@ -230,9 +230,6 @@ namespace TiltBrush
                     var unused = msg.Data.AgeCategory;
                 });
             }
-#if PASSTHROUGH_SUPPORTED
-            OVRManager.eyeFovPremultipliedAlphaModeEnabled = false;
-#endif
 
 #endif // OCULUS_SUPPORTED
 


### PR DESCRIPTION
I can't figure out where I got the idea setting eyeFovPremultipliedAlphaModeEnabled to false was necessary when I implemented the passthrough brush. I was following a tutorial or some docs but I can't find the source now.