### PR TITLE
Add Pico support to the generic OpenXR build

### DIFF
--- a/Assets/Plugins/Android/AndroidManifest.xml
+++ b/Assets/Plugins/Android/AndroidManifest.xml
@@ -16,6 +16,7 @@
             </intent-filter>
         </activity>
         <meta-data android:name="unityplayer.SkipPermissionsDialog" android:value="false" />
+        <meta-data android:name="pvr.app.type" android:value="vr" />
     </application>
     <uses-permission android:name="android.permission.RECORD_AUDIO" tools:node="remove"/>
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>


### PR DESCRIPTION
Adds the manifest line that means the OpenXR build can run on Pico without a custom loader.