### PR TITLE
Revert "Run ovr-platform-util on Linux instead of Mac (#727)"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1064,7 +1064,7 @@ jobs:
   publish_oculus_quest:
     name: Publish Oculus Quest 2+ Release
     needs: [configuration, build]
-    runs-on: ubuntu-latest
+    runs-on: macos-latest  # the ovr-platform-util tool is only available for Mac and Windows
     if: |
       github.event_name == 'push' &&
       github.repository == 'icosa-foundation/open-brush' &&
@@ -1090,7 +1090,7 @@ jobs:
 
           cd releases
           unzip symbols.zip
-          curl -L 'https://www.oculus.com/download_app/?id=5159709737372459' -o ovr-platform-util
+          curl -L 'https://www.oculus.com/download_app/?id=1462426033810370' -o ovr-platform-util
           chmod 755 ovr-platform-util
 
           if [ "$PRERELEASE" == "false" ]
@@ -1104,7 +1104,7 @@ jobs:
   publish_oculus_quest1:
     name: Publish Oculus Quest 1 Release
     needs: [configuration, build]
-    runs-on: ubuntu-latest
+    runs-on: macos-latest  # the ovr-platform-util tool is only available for Mac and Windows
     if: |
       github.event_name == 'push' &&
       github.repository == 'icosa-foundation/open-brush' &&
@@ -1130,7 +1130,7 @@ jobs:
 
           cd releases1
           unzip symbols.zip
-          curl -L 'https://www.oculus.com/download_app/?id=5159709737372459' -o ovr-platform-util
+          curl -L 'https://www.oculus.com/download_app/?id=1462426033810370' -o ovr-platform-util
           chmod 755 ovr-platform-util
 
           if [ "$PRERELEASE" == "false" ]
@@ -1144,7 +1144,7 @@ jobs:
   publish_oculus_rift:
     name: Publish Oculus Rift Release
     needs: [configuration, build]
-    runs-on: ubuntu-latest
+    runs-on: macos-latest  # the ovr-platform-util tool is only available for Mac and Windows
     if: |
       github.event_name == 'push' &&
       github.repository == 'icosa-foundation/open-brush' &&
@@ -1168,7 +1168,7 @@ jobs:
           mv build_windows_rift/StandaloneWindows64/ releases/OpenBrush_Rift_$VERSION/
           cd releases
           zip -r OpenBrush_Rift_$VERSION.zip OpenBrush_Rift_$VERSION/
-          curl -L 'https://www.oculus.com/download_app/?id=5159709737372459' -o ovr-platform-util
+          curl -L 'https://www.oculus.com/download_app/?id=1462426033810370' -o ovr-platform-util
           chmod 755 ovr-platform-util
 
           if [ "$PRERELEASE" == "false" ]


### PR DESCRIPTION
This reverts commit 5a50f048cd0c3dbd555815ea04c2719275fdc3e0.

While it appears to be fully functional, it turns out that the Linux version doesn't handle the --age-group parameter correctly. Until this is resolved, revert to Mac