### PR TITLE
Fix background image seams by bypassing cache for now

### DIFF
--- a/Assets/Scripts/GUI/LoadBackgroundImageButton.cs
+++ b/Assets/Scripts/GUI/LoadBackgroundImageButton.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.IO;
 using UnityEngine;
 using UnityEngine.Localization;
 
@@ -54,7 +55,10 @@ namespace TiltBrush
             }
 
 
-            SceneSettings.m_Instance.LoadCustomSkyboxFromCache(ReferenceImage.FilePath);
+            // TODO we had problems with seams when using the cached image.
+            // Likely related to mipmaps but I couldn't track down the cause.
+            // SceneSettings.m_Instance.LoadCustomSkyboxFromCache(ReferenceImage.FilePath);
+            SceneSettings.m_Instance.LoadCustomSkybox(Path.GetFileName(ReferenceImage.FilePath));
         }
 
         override public void ResetState()


### PR DESCRIPTION
I tried to track down the cause but couldn't see anything. Considering it's just an optimization disabling it for now seemed like the best option