### PR TITLE
initial fix: enable unpacking GLTF models multiple levels

### DIFF
--- a/Assets/Scripts/Widgets/ModelWidget.cs
+++ b/Assets/Scripts/Widgets/ModelWidget.cs
@@ -333,7 +333,18 @@ namespace TiltBrush
             string subpathToTraverse;
             if (!string.IsNullOrEmpty(previousSubtree))
             {
-                subpathToTraverse = m_Subtree.Substring(previousSubtree.Length);
+
+                // example case:
+                //      previousSubtree = CarBody/Floor
+                //      m_Subtree = CarBody/Floor/Wheel1
+                //      subpathToTraverse should be Floor/Wheel1
+
+                // Floor
+                string lastLevel = previousSubtree.Split("/")[^1];
+
+                int startIndex = previousSubtree.Length - (lastLevel.Length + "/".Length);
+
+                subpathToTraverse = m_Subtree.Substring(startIndex);
             }
             else
             {


### PR DESCRIPTION
This is an initial fix; Not ready for merge yet. It hasn't been tested enough, so idk if it works for all kinds of GLTF transform hierarchies.

This fixes one major issue with the feature. Previously, you couldn't break apart a certain kind of GLTF model more than once, as it would just create duplicates of the thing you were trying to break apart.

**Demo of breaking up GLTF model multiple times:** https://youtu.be/Tb2jOGZF4fg