### PR TITLE
Do not use # in PR build names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,7 +146,7 @@ jobs:
           else
             if [[ ${{ github.ref }} == refs/pull/* ]]
             then
-              DESCRIPTION="PR#$(echo ${{ github.ref }} | sed -e 's#refs/pull/##' -e 's#/merge##')"
+              DESCRIPTION="PR$(echo ${{ github.ref }} | sed -e 's#refs/pull/##' -e 's#/merge##')"
             elif [[ ${{ github.ref }} == refs/heads/* ]]
             then
               DESCRIPTION="$(echo ${{ github.ref }} | sed -e 's#refs/heads/##')"

--- a/Assets/Editor/BuildTiltBrush.cs
+++ b/Assets/Editor/BuildTiltBrush.cs
@@ -1032,7 +1032,7 @@ static class BuildTiltBrush
 #endif
             if (!String.IsNullOrEmpty(Description))
             {
-                new_name += "-(" + Description + ")";
+                new_name += "-(" + Description.Replace("#", "") + ")";
                 new_identifier += "-" + Description.Replace("_", "").Replace("#", "").Replace("-", "");
             }
             if (m_IsAndroidOrIos)


### PR DESCRIPTION
Currently, this creates a User Data folder at `file://C:\Users\foo\AppData\LocalLow\Icosa Foundation\Open Brush-(PR#1234)\` which breaks GLTF loading. This PR removes the # if set, and stops trying to set it in the first place.