### PR TITLE
Support new ubuntu-24 images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -268,7 +268,7 @@ jobs:
           echo "Initial free space"
           df -h /
           echo "Removing all pre-loaded docker images"
-          docker rmi $(docker image ls -aq)  # Removes ~3GB
+          docker image ls -aq | xargs -r docker rmi # Removes ~3GB
           df -h /
           echo "Listing 100 largest packages"
           dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -rn | head -n 100


### PR DESCRIPTION
Fix the "remove preloaded docker images" step to not fail if there are no images.

It should have been written this way all along...