### PR TITLE
Catch wmic exceptions so they don't mess up device initialization

### DIFF
--- a/Assets/Scripts/Sharing/DriveAccess.cs
+++ b/Assets/Scripts/Sharing/DriveAccess.cs
@@ -120,7 +120,15 @@ namespace TiltBrush
                     Debug.LogError("Host id not implemented for iOS");
                     return "iOS-unknown";
                 default:
-                    return GetPcId();
+                    try
+                    {
+                        return GetPcId();
+                    }
+                    catch (Exception e)
+                    {
+                        // We suspect wmic.xe can cause an exception on some systems, so we catch it here.
+                        return "PC-unknown";
+                    }
             }
         }
 


### PR DESCRIPTION
Seems like a sensible change even if wmic isn't causing the black screen problem with controllers on some PC systems