### PR TITLE
Fix quality level bugs

### DIFF
--- a/Assets/QualityLevels.asset
+++ b/Assets/QualityLevels.asset
@@ -29,7 +29,7 @@ MonoBehaviour:
     m_GpuLevel: 4
     m_FixedFoveationLevel: 0
   - m_Bloom: 1
-    m_Hdr: 0
+    m_Hdr: 1
     m_Fxaa: 1
     m_MsaaLevel: 1
     m_MaxLod: 99999999

--- a/ProjectSettings/QualitySettings.asset
+++ b/ProjectSettings/QualitySettings.asset
@@ -88,7 +88,7 @@ QualitySettings:
     shadows: 1
     shadowResolution: 2
     shadowProjection: 1
-    shadowCascades: 1
+    shadowCascades: 2
     shadowDistance: 30
     shadowNearPlaneOffset: 2
     shadowCascade2Split: 0.33333334


### PR DESCRIPTION
1. The default (Unity) quality level "High Performance Desktop" had a weird shadow artifact. It as especially visible in the Dress Form environment and appeared as a line on the ground where shadowing suddenly started/stopped. Increasing the shadow cascade setting by one notch seemed to fix it (two cascades instead of no cascades)
2. The second (Open Brush) quality setting (so level 1 or 2 depending if you count from zero) was glitching out to all white. It seemed to happen when HDR was off but FXAA was on? I turned HDR on for this quality level and it seems to resolve it.

In both cases the I decided to solve the issue by trading for a hopefully small decrease in performance as I figured average user hardware has increased over time.