### PR TITLE
Guard against tracking glitches that effect painting

### DIFF
--- a/Assets/Scripts/Tools/FreePaintTool.cs
+++ b/Assets/Scripts/Tools/FreePaintTool.cs
@@ -210,6 +210,15 @@ namespace TiltBrush
 
         void PositionPointer()
         {
+            // Discard the pointer if the controller is exactly zero
+            // as it probably indicates the controller tracking stalled this frame
+            // TODO: is there a better solution?
+            if (InputManager.m_Instance.GetControllerBehavior(InputManager.ControllerName.Brush).transform.position == Vector3.zero)
+            {
+                Debug.LogError($"Controller Glitch!");
+                return;
+            }
+
             // Angle the pointer according to the user-defined pointer angle.
             Transform rAttachPoint = InputManager.m_Instance.GetBrushControllerAttachPoint();
             Vector3 pos = rAttachPoint.position;


### PR DESCRIPTION
This is not a pretty fix - it basically ignores calls to PositionPointer that are exactly at the origin. This should never happen in normal uses and only affects the FreePaintTool. Scripts and other proc-gen uses bypass PositionPointer so should not be affected.

But it's still an ugly fix. Is there something we could do lower down the stack?

@mikeskydev - You're more familiar with input system and controller tracking. I think this is related to high-CPU or some other system overload scenario but I can't pin it down precisely.