### PR TITLE
Allow the erase tool to also "erase" media widgets

### DIFF
--- a/Assets/Scripts/Tools/EraserTool.cs
+++ b/Assets/Scripts/Tools/EraserTool.cs
@@ -84,6 +84,13 @@ namespace TiltBrush
 
         override protected bool HandleIntersectionWithWidget(GrabWidget widget)
         {
+            if (widget is MediaWidget)
+            {
+                SketchMemoryScript.m_Instance.PerformAndRecordCommand(new HideWidgetCommand(widget));
+                AudioManager.m_Instance.ShowHideWidget(false, transform.position);
+                PlayModifyStrokeSound();
+                return true;
+            }
             return false;
         }
 


### PR DESCRIPTION
A win for usability in my view.

This is a simple implementation. It would be nice to have a "shrink" animation like there is when erasing brush strokes.