### PR TITLE
Update Zapbox SDK to 0.4.0

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -28,7 +28,7 @@
     "com.unity.xr.management": "4.4.1",
     "com.unity.xr.oculus": "4.2.0",
     "com.unity.xr.openxr": "1.10.0",
-    "com.zappar.xr.zapbox": "https://github.com/zappar-xr/zapbox-xr-sdk.git#43697771ed65efee02d5b1743141b8179444c147",
+    "com.zappar.xr.zapbox": "https://github.com/zappar-xr/zapbox-xr-sdk.git#74fe120c1c9a0b31a186eb551ef25efe4a316c73",
     "org.khronos.unitygltf": "https://github.com/icosa-mirror/UnityGLTF.git",
     "org.nuget.google.apis": "1.64.0",
     "org.nuget.google.apis.auth": "1.64.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -361,14 +361,14 @@
       "url": "https://packages.unity.com"
     },
     "com.zappar.xr.zapbox": {
-      "version": "https://github.com/zappar-xr/zapbox-xr-sdk.git#43697771ed65efee02d5b1743141b8179444c147",
+      "version": "https://github.com/zappar-xr/zapbox-xr-sdk.git#74fe120c1c9a0b31a186eb551ef25efe4a316c73",
       "depth": 0,
       "source": "git",
       "dependencies": {
         "com.unity.xr.management": "3.2.9",
         "com.unity.xr.legacyinputhelpers": "2.1.4"
       },
-      "hash": "43697771ed65efee02d5b1743141b8179444c147"
+      "hash": "74fe120c1c9a0b31a186eb551ef25efe4a316c73"
     },
     "org.khronos.unitygltf": {
       "version": "https://github.com/icosa-mirror/UnityGLTF.git",


### PR DESCRIPTION
The previous Zapbox SDK has expired so requires an update. The current build on the App Store exits on launch (unless you manually set the date to 31 March or before).

One new feature in this version of the SDK is automatic calibration of the analog trigger, which should prevent the issues I was seeing with some of my Zapbox controllers the last time we came to do this update in October. Hopefully that means we can get the Zapbox builds up-to-date with other platforms now rather than needing to maintain the old branch.

I haven't actually tested this yet, hoping the CI will magically produce a build I can try out.

I know Abdi has submitted a pull request with the tutorial stuff enabled. I thought I'd do this one separately as it's a small change that can hopefully be approved quickly to fix the live App Store build.