### PR TITLE
Remove old "not supported" code that sneaked back in with plugin merge

### DIFF
--- a/Assets/Scripts/GUI/SketchbookPanel.cs
+++ b/Assets/Scripts/GUI/SketchbookPanel.cs
@@ -49,7 +49,6 @@ namespace TiltBrush
         [SerializeField] private GameObject m_NoShowcaseMessage;
         [SerializeField] private GameObject m_ContactingServerMessage;
         [SerializeField] private GameObject m_OutOfDateMessage;
-        [SerializeField] private GameObject m_NotSupportedMessage;
         [SerializeField] private GameObject m_NoPolyConnectionMessage;
         [SerializeField] private Renderer m_OnlineGalleryButtonRenderer;
         [SerializeField] private GameObject[] m_IconsOnFirstPage;
@@ -308,15 +307,7 @@ namespace TiltBrush
             bool outOfDate = !polyDown && !VrAssetService.m_Instance.Available && requiresPoly;
             m_OutOfDateMessage.SetActive(outOfDate);
 
-            bool notSupported = false;
-#if UNITY_ANDROID && OCULUS_SUPPORTED
-            notSupported = !polyDown && !outOfDate && OVRPlugin.GetSystemHeadsetType() == OVRPlugin.SystemHeadset.Oculus_Quest
-                && (m_CurrentSketchSet == SketchSetType.Curated
-                || m_CurrentSketchSet == SketchSetType.Liked);
-            m_NotSupportedMessage.SetActive(notSupported);
-#endif
-
-            if (outOfDate || polyDown || notSupported)
+            if (outOfDate || polyDown)
             {
                 m_NoSketchesMessage.SetActive(false);
                 m_NoDriveSketchesMessage.SetActive(false);


### PR DESCRIPTION
This is code from 2021's "disable poly" PR. Don't know quite why it came back via the plugin branch and I can't see any reason to keep it.