### PR TITLE
Add support for periodically (monthly) rebuilding a PR

### DIFF
--- a/.github/workflows/periodic_rebuilds.yml
+++ b/.github/workflows/periodic_rebuilds.yml
@@ -1,0 +1,84 @@
+---
+# yamllint disable rule:line-length
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Periodic PR Rebuilds
+
+on:  # yamllint disable-line rule:truthy
+  schedule:
+    - cron: '0 7 * * 4'  # Every Thursday at 07:00 UTC
+  workflow_dispatch:
+
+jobs:
+  find-and-rerun-prs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Set up GitHub CLI
+        uses: cli/cli-action@v2
+
+      - name: Print repository context
+        run: |
+          echo "Repository: ${{ github.repository }}"
+          echo "Event: ${{ github.event_name }}"
+
+      - name: List open PRs with label 'periodic rebuild'
+        id: list_prs
+        run: |
+          echo "Listing PRs with label 'periodic rebuild'..."
+          gh pr list --state open --label "periodic rebuild" --json number,title,headRefName | tee prs.json
+          cat prs.json | jq -r '.[] | "PR #" + (.number|tostring) + ": " + .title + " (branch: " + .headRefName + ")"'
+          cat prs.json | jq '.[].number' > prs.txt
+          echo "Total PRs found:" $(wc -l < prs.txt)
+        env:
+          GH_TOKEN: ${{ secrets.REBUILD_PAT }}
+
+      - name: Rerun last build workflow for each PR
+        run: |
+          set -e
+          if [ ! -s prs.txt ]; then
+            echo "No PRs to process."
+            exit 0
+          fi
+
+          while read pr_number; do
+            echo "----------------------"
+            echo "Processing PR #$pr_number"
+
+            pr_branch=$(jq -r '.[] | select(.number=='"$pr_number"') | .headRefName' prs.json)
+            echo "PR branch: $pr_branch"
+
+            echo "Finding latest workflow run for 'Builds' on branch '$pr_branch'..."
+
+            workflow_run=$(gh api repos/${{ github.repository }}/actions/runs \
+              --paginate \
+              -F "event=pull_request" \
+              -F "branch=$pr_branch" \
+              --jq '.workflow_runs[] | select(.name=="Builds")' | jq -s 'sort_by(.created_at) | reverse | .[0]')
+
+            if [ "$workflow_run" = "null" ] || [ -z "$workflow_run" ]; then
+              echo "No 'Builds' workflow run found for PR #$pr_number (branch: $pr_branch)"
+              continue
+            fi
+
+            run_id=$(echo "$workflow_run" | jq -r '.id')
+            run_status=$(echo "$workflow_run" | jq -r '.status')
+            run_conclusion=$(echo "$workflow_run" | jq -r '.conclusion')
+            run_created_at=$(echo "$workflow_run" | jq -r '.created_at')
+            echo "Found workflow run:"
+            echo "  ID: $run_id"
+            echo "  Status: $run_status"
+            echo "  Conclusion: $run_conclusion"
+            echo "  Created At: $run_created_at"
+
+            echo "Rerunning workflow run ID $run_id..."
+            gh api -X POST repos/${{ github.repository }}/actions/runs/$run_id/rerun
+            echo "Rerun triggered for run ID $run_id."
+          done < prs.txt
+        env:
+          GH_TOKEN: ${{ secrets.REBUILD_PAT }}
+
+      - name: Clean up
+        run: rm -f prs.json prs.txt

--- a/.github/workflows/periodic_rebuilds.yml
+++ b/.github/workflows/periodic_rebuilds.yml
@@ -5,7 +5,7 @@ name: Periodic PR Rebuilds
 
 on:  # yamllint disable-line rule:truthy
   schedule:
-    - cron: '0 7 * * 4'  # Every Thursday at 07:00 UTC
+    - cron: '14 3 1 * *'  # Monthly, 1st of the month, 03:14 UTC
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This can be used for PRs that are not ready to be merged / won't be ready for a while, but we want to keep them alive. Note that it's better to *not* do this, and just keep the PR up to date by merging in `main`, etc.

This relies on a secret called `REBUILD_PAT` which needs to have permissions for `actions` and `code` (read/write). The current secret is valid until mid-2026