### PR TITLE
Use indices rather than InstanceId to ensure unique names that persist across sessions

### DIFF
--- a/Assets/Scripts/Model.cs
+++ b/Assets/Scripts/Model.cs
@@ -990,19 +990,15 @@ namespace TiltBrush
         {
             void SetUniqueNameForNode(Transform node)
             {
-                // GetInstanceID returns a unique ID for every GameObject during a runtime session
-                node.name += " uid: " + node.gameObject.GetInstanceID();
-
+                int index = 0;
                 foreach (Transform child in node)
                 {
+                    child.name += $"[{index++}]";
                     SetUniqueNameForNode(child);
                 }
             }
 
-            foreach (Transform child in rootNode)
-            {
-                SetUniqueNameForNode(child);
-            }
+            SetUniqueNameForNode(rootNode);
         }
 
         public void UnloadModel()


### PR DESCRIPTION
Fixes issue where scenes with "broken apart" models didn't load correctly in a new session.