### PR TITLE
Fix publish jobs and some general build cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -821,7 +821,7 @@ jobs:
           path: build_android_openxr
 
       - name: Download Build Artifacts (Android Quest)
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: Android Meta Quest
           path: build_android_quest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1103,11 +1103,11 @@ jobs:
           name: Windows OpenXR
           path: build_windows_openxr
 
-      - name: Download Build Artifacts (Android OpenXR)
+      - name: Download Build Artifacts (Android Quest)
         uses: actions/download-artifact@v8
         with:
-          name: Android OpenXR
-          path: build_android_openxr
+          name: Android Meta Quest
+          path: build_android_quest
 
       - name: Download Build Artifacts (Mac)
         uses: actions/download-artifact@v8
@@ -1118,7 +1118,7 @@ jobs:
       - name: Package Artifacts for release
         run: |
           mkdir releases
-          mv build_android_openxr/*/com.Icosa.OpenBrush*apk releases/OpenBrush_Android_$VERSION.apk
+          mv build_android_quest/*/com.Icosa.OpenBrush*apk releases/OpenBrush_Quest_$VERSION.apk
           mv build_windows_openxr/StandaloneWindows64/ releases/OpenBrush_Desktop_$VERSION/
           mv build_macos/*.dmg releases/OpenBrush_Mac_$VERSION.dmg
 
@@ -1131,7 +1131,7 @@ jobs:
         uses: yeslayla/butler-publish-itchio-action@master
         env:
           CHANNEL: android-quest-${{ env.ITCH_SUBCHANNEL_NAME }}
-          PACKAGE: releases/OpenBrush_Android_${{ needs.configuration.outputs.version }}.apk
+          PACKAGE: releases/OpenBrush_Quest_${{ needs.configuration.outputs.version }}.apk
       - name: Publish Mac
         uses: yeslayla/butler-publish-itchio-action@master
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1409,7 +1409,7 @@ jobs:
       - name: Download Build Artifacts (Android Quest)
         uses: actions/download-artifact@v8
         with:
-          name: Android OpenXR
+          name: Android Meta Quest
           path: build_android_quest
 
       - name: Publish Oculus Builds
@@ -1460,11 +1460,10 @@ jobs:
         run: |
           uv tool install abxrcli --with 'setuptools<82.0.0'
 
-      - name: Download Build Artifacts (Android OpenXR)
+      - name: Download Build Artifacts (Android Quest)
         uses: actions/download-artifact@v8
         with:
-          # ArborXR is not the Meta store, including when the device is a Quest.
-          name: Android OpenXR
+          name: Android Meta Quest
           path: build_android_quest
       - name: Publish Oculus Builds
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -322,7 +322,8 @@ jobs:
       - name: Set masking
         run: echo "::add-mask::DoNotStealThis1"
       - name: Free extra space
-        # As of 02/08/2024, this increases free space from 21GB to 47GB
+        # As of 09/09/26, we start with 86GB of free space and this gives us a total of 115GB. But we really don't need that much space, so this is now disabled
+        if: false
         run: |
           echo "Initial free space"
           df -h /

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -691,11 +691,7 @@ jobs:
 
           pushd StandaloneOSX/
 
-          # Sign every native binary explicitly. Unity packages can add standalone
-          # dylibs as well as bundles, and codesign --deep does not reliably replace
-          # an existing ad-hoc signature on those files (as happened with
-          # libImmStrokeReader.dylib). Sign code from the inside out, then seal its
-          # containing bundle and finally the application itself.
+          # Sign every native binary explicitly. Sign code from the inside out, then seal its containing bundle and finally the application itself.
           while IFS= read -r -d '' native_file; do
               if file -b "$native_file" | grep -q 'Mach-O'; then
                   codesign --force --verify --verbose --timestamp --options runtime --sign "Developer ID Application: Icosa Gallery Ltd (${{ vars.APPLE_TEAM_ID }})" "$native_file"
@@ -708,8 +704,6 @@ jobs:
             -name '*.app' -o -name '*.bundle' -o -name '*.framework' -o \
             -name '*.plugin' -o -name '*.xpc' \) -print0)
 
-          # These exceptions are needed by the Unity player, but should not be
-          # copied onto libraries and plug-ins that do not need entitlements.
           codesign --force --verify --verbose --timestamp --options runtime --entitlements ../Support/macos/OpenBrush.entitlements --sign "Developer ID Application: Icosa Gallery Ltd (${{ vars.APPLE_TEAM_ID }})" "$FILENAME"
           codesign --verify --deep --strict --verbose=4 "$FILENAME"
           popd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -681,15 +681,38 @@ jobs:
         run: |
           tar xvfz build_macos/*tgz
 
-          export FILENAME=$(basename $(readlink -f StandaloneOSX/OpenBrush*.app))
+          shopt -s nullglob
+          APP_PATHS=(StandaloneOSX/OpenBrush*.app)
+          if [[ ${#APP_PATHS[@]} -ne 1 ]]; then
+            echo "Expected exactly one OpenBrush app, found ${#APP_PATHS[@]}."
+            exit 1
+          fi
+          FILENAME=$(basename "$(readlink -f "${APP_PATHS[0]}")")
 
-          cd StandaloneOSX/
-          codesign --deep --force --verify --verbose --timestamp --options runtime --entitlements ../Support/macos/OpenBrush.entitlements --sign "Developer ID Application: Icosa Gallery Ltd (${{ vars.APPLE_TEAM_ID }})" $FILENAME/Contents/Support/ThirdParty/ffmpeg/bin/ffmpeg
-          for bundle in $FILENAME/Contents/Plugins/*.bundle; do
-              codesign --deep --force --verify --verbose --timestamp --options runtime --entitlements ../Support/macos/OpenBrush.entitlements --sign "Developer ID Application: Icosa Gallery Ltd (${{ vars.APPLE_TEAM_ID }})" $bundle
-          done
-          codesign --deep --force --verify --verbose --timestamp --options runtime --entitlements ../Support/macos/OpenBrush.entitlements --sign "Developer ID Application: Icosa Gallery Ltd (${{ vars.APPLE_TEAM_ID }})" $FILENAME
-          cd -
+          pushd StandaloneOSX/
+
+          # Sign every native binary explicitly. Unity packages can add standalone
+          # dylibs as well as bundles, and codesign --deep does not reliably replace
+          # an existing ad-hoc signature on those files (as happened with
+          # libImmStrokeReader.dylib). Sign code from the inside out, then seal its
+          # containing bundle and finally the application itself.
+          while IFS= read -r -d '' native_file; do
+              if file -b "$native_file" | grep -q 'Mach-O'; then
+                  codesign --force --verify --verbose --timestamp --options runtime --sign "Developer ID Application: Icosa Gallery Ltd (${{ vars.APPLE_TEAM_ID }})" "$native_file"
+              fi
+          done < <(find "$FILENAME" -type f -print0)
+
+          while IFS= read -r -d '' code_bundle; do
+              codesign --force --verify --verbose --timestamp --options runtime --sign "Developer ID Application: Icosa Gallery Ltd (${{ vars.APPLE_TEAM_ID }})" "$code_bundle"
+          done < <(find "$FILENAME/Contents" -depth -type d \( \
+            -name '*.app' -o -name '*.bundle' -o -name '*.framework' -o \
+            -name '*.plugin' -o -name '*.xpc' \) -print0)
+
+          # These exceptions are needed by the Unity player, but should not be
+          # copied onto libraries and plug-ins that do not need entitlements.
+          codesign --force --verify --verbose --timestamp --options runtime --entitlements ../Support/macos/OpenBrush.entitlements --sign "Developer ID Application: Icosa Gallery Ltd (${{ vars.APPLE_TEAM_ID }})" "$FILENAME"
+          codesign --verify --deep --strict --verbose=4 "$FILENAME"
+          popd
 
           tar -c -v -z -f OpenBrush.tgz StandaloneOSX
       - name: Upload signed app
@@ -729,8 +752,8 @@ jobs:
         run: |
           tar xvfz build_macos/*tgz
 
-          export FILENAME=$(basename $(readlink -f StandaloneOSX/OpenBrush*.app))
           mkdir dist
+          export FILENAME=$(basename $(readlink -f StandaloneOSX/OpenBrush*.app))
 
           cp Support/macos/background.png StandaloneOSX/
           cp Support/macos/background@2x.png StandaloneOSX/
@@ -740,12 +763,26 @@ jobs:
           npx appdmg openbrush-dmg.json ../dist/OpenBrush.dmg
           popd
 
-          xcrun notarytool submit \
-          --team-id ${{ vars.APPLE_TEAM_ID }} \
-          --apple-id ${{ vars.APPLE_ID }} \
-          --password ${{ secrets.APPLE_APPLICATION_SPECIFIC_PASSWORD }} \
-          --wait \
-          dist/OpenBrush.dmg
+          NOTARY_RESULT="$RUNNER_TEMP/notary-result.json"
+
+          set +e
+          xcrun notarytool submit dist/OpenBrush.dmg --team-id ${{ vars.APPLE_TEAM_ID }} --apple-id ${{ vars.APPLE_ID }} --password ${{ secrets.APPLE_APPLICATION_SPECIFIC_PASSWORD }} --wait --output-format json > "$NOTARY_RESULT"
+          NOTARY_EXIT=$?
+          set -e
+
+          cat "$NOTARY_RESULT"
+          SUBMISSION_ID=$(plutil -extract id raw -o - "$NOTARY_RESULT" 2>/dev/null || true)
+          NOTARY_STATUS=$(plutil -extract status raw -o - "$NOTARY_RESULT" 2>/dev/null || true)
+
+          if [[ -n "$SUBMISSION_ID" && "$NOTARY_STATUS" != "Accepted" ]]; then
+            echo "Notarization returned '$NOTARY_STATUS'; fetching Apple's diagnostic log."
+            xcrun notarytool log "$SUBMISSION_ID" --team-id ${{ vars.APPLE_TEAM_ID }} --apple-id ${{ vars.APPLE_ID }} --password ${{ secrets.APPLE_APPLICATION_SPECIFIC_PASSWORD }} || true
+          fi
+
+          if [[ $NOTARY_EXIT -ne 0 || "$NOTARY_STATUS" != "Accepted" ]]; then
+            echo "Notarization failed (exit=$NOTARY_EXIT, status='$NOTARY_STATUS')."
+            exit 1
+          fi
 
           xcrun stapler staple dist/OpenBrush.dmg
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -527,7 +527,6 @@ jobs:
           retry_condition: steps._this.outputs.engineExitCode == 1
           action: game-ci/unity-builder@v5
           with: |
-            allowDirtyBuild: true  # Because of the OVR Update, the build tree might be dirty
             unityVersion: ${{ env.UNITY_VERSION }}
             targetPlatform: ${{ matrix.targetPlatform }}
             customParameters: -btb-target ${{ matrix.targetPlatform }} -btb-display ${{ matrix.vrsdk }} -btb-out /github/workspace/build/${{ matrix.vrsdk }}/${{ matrix.targetPlatform }}/${{ env.filename }} ${{ matrix.androidExportType != 'androidAppBundle' && needs.configuration.outputs.description || '' }} ${{ env.stamp }} ${{ env.btbbopts }} ${{ matrix.extraoptions }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,8 +117,8 @@ jobs:
             GOOGLE_PLAY_TRACKS="$GOOGLE_PLAY_PRERELEASE_TRACK"
             GOOGLE_PLAY_STATUS="$GOOGLE_PLAY_PRERELEASE_STATUS"
           fi
-          # upload-google-play accepts a comma-separated track list. Remove
-          # whitespace before exporting it, then match the exact production token.
+
+          # upload-google-play accepts a comma-separated track list. Remove whitespace before exporting it, then match the exact production token.
           NORMALIZED_GOOGLE_PLAY_TRACKS="$(printf '%s' "$GOOGLE_PLAY_TRACKS" | tr -d '[:space:]')"
           echo "googleplaytrack=$NORMALIZED_GOOGLE_PLAY_TRACKS" >> $GITHUB_OUTPUT
           echo "googleplaystatus=$GOOGLE_PLAY_STATUS" >> $GITHUB_OUTPUT
@@ -127,6 +127,7 @@ jobs:
             *,production,*) echo "googleplayhasproduction=true" >> $GITHUB_OUTPUT ;;
             *) echo "googleplayhasproduction=false" >> $GITHUB_OUTPUT ;;
           esac
+
           VERSION=$(echo "$MAJOR_MINOR.$PATCH_VERSION" | sed -e 's/^v//')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "stamp=$STAMP" >> $GITHUB_OUTPUT
@@ -300,8 +301,7 @@ jobs:
           # The Meta store requires its original application ID, irrespective of the XR loader.
           - name: Android Meta Quest
             targetPlatform: Android
-            # Meta upload validation rejects SDK 35; keep this separate from Google Play.
-            androidTargetSdkVersion: AndroidApiLevel34
+            androidTargetSdkVersion: AndroidApiLevel34  # Meta upload validation rejects SDK 35; keep this separate from Google Play.
             vrsdk: OpenXR
             cache: Android_Vulkan
             extraoptions: -btb-il2cpp
@@ -1151,8 +1151,7 @@ jobs:
       viewer_changes_not_sent_for_review: ${{ steps.review_state.outputs.viewer_changes_not_sent_for_review }}
 
     steps:
-      # google-github-actions/auth writes its temporary credentials beneath the
-      # workspace, so checkout must run first even though this job reads no files.
+      # google-github-actions/auth writes its temporary credentials beneath the workspace, so checkout must run first even though this job reads no files.
       - name: Checkout repository
         uses: actions/checkout@v7
 
@@ -1209,8 +1208,7 @@ jobs:
               --data '{}' \
               "$API_ROOT/$package_name/edits/$edit_id:validate")" || curl_status=$?
 
-            # The probe edit contains no changes, but delete it explicitly so
-            # it cannot linger until Google's edit-expiry timeout.
+            # The probe edit contains no changes, but delete it explicitly so it cannot linger until Google's edit-expiry timeout.
             curl --fail-with-body --silent --show-error \
               --request DELETE \
               --header "Authorization: Bearer $ACCESS_TOKEN" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ on:  # yamllint disable-line rule:truthy
 
 env:
   UNITY_VERSION: "6000.6.0f1"
-  UNITY_LIBRARY_CACHE_PATHS: "DataStore ArtifactDB SourceAssetDB PlayerDataCache ShaderCache ShaderCache.db"
   PHOTON_PAT: ${{ secrets.PHOTON_PAT }}  # This needs to be here, since you can't use a ${{ secrets }} within an if: condition
 jobs:
   configuration:
@@ -585,6 +584,7 @@ jobs:
         if: false && github.ref == 'refs/heads/main' && steps.check_packagecache.outputs.changes == 0 && steps.cache_packagecache.outputs.cache-hit != 'true' && ! matrix.packages_to_remove  # Ideally, we'd save caches on branches, but they're too big, and branch caches can evict those from main, which is unacceptable.
         env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 10
+          UNITY_LIBRARY_CACHE_PATHS: "DataStore ArtifactDB SourceAssetDB PlayerDataCache ShaderCache ShaderCache.db"
         with:
           path: Library/PackageCache
           key: Library_PackageCache_${{ env.UNITY_VERSION }}_${{ hashFiles('Packages/packages-lock.json') }}

--- a/Assets/Plugins/iOS.meta
+++ b/Assets/Plugins/iOS.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 440eb04a8d9b48fe9b11ea4bb84a271a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/iOS/ZapboxUnity6Compatibility.mm
+++ b/Assets/Plugins/iOS/ZapboxUnity6Compatibility.mm
@@ -1,0 +1,11 @@
+// Zapbox XR SDK 0.3.1's precompiled GfxPluginZapbox.a references the global
+// _skipPresent variable that was supplied by Unity's generated iOS player in
+// Unity 2022 and earlier. Unity 6 no longer defines it, which makes Xcode fail
+// to link UnityFramework with an undefined __skipPresent Mach-O symbol.
+//
+// Keep this as a weak definition so a Unity player that still supplies the
+// original strong definition takes precedence. On Unity 6 this is only an ABI
+// compatibility shim: Unity no longer observes the value. Zapbox should
+// ultimately rebuild its native library without relying on this private Unity
+// implementation detail.
+bool _skipPresent __attribute__((weak)) = false;

--- a/Assets/Plugins/iOS/ZapboxUnity6Compatibility.mm.meta
+++ b/Assets/Plugins/iOS/ZapboxUnity6Compatibility.mm.meta
@@ -1,0 +1,51 @@
+fileFormatVersion: 2
+guid: f58a12f118c24c10906573ae7cc1e3d7
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 1
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude WebGL: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude iOS: 0
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: AnyCPU
+        CompileFlags: 
+        FrameworkDependencies: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -79,7 +79,7 @@ platform :ios do
     build_app( #alias: gym
       project: "#{ENV['IOS_BUILD_PATH']}/Unity-iPhone.xcodeproj",
       scheme: 'Unity-iPhone',
-      xcargs: '-allowProvisioningUpdates OTHER_LDFLAGS="-ld_classic"'
+      xcargs: '-allowProvisioningUpdates'
     )
   end
 


### PR DESCRIPTION
Followup to #1069 

Main changes:
* Use the Quest specific build for ArborXR and Itch, rather than the generic Android OpenXR
* Sign all required files for the DMG
* Fix Zapbox by removing a parameter required for earlier Unity versions and adding a stub for a variable that Unity removed. 
* Skip the free disk space check, since the newer workers have plenty of space without it
* Clean up a bit of AI self-documentation and parameters no longer needed